### PR TITLE
chore: remove unneeded classes in richtext.tsx

### DIFF
--- a/apps/web/src/components/richtext.tsx
+++ b/apps/web/src/components/richtext.tsx
@@ -68,10 +68,6 @@ const components: Partial<PortableTextReactComponents> = {
       );
     },
   },
-  list: {
-    bullet: ({ children }) => <ul>{children}</ul>,
-    number: ({ children }) => <ol>{children}</ol>,
-  },
   types: {
     image: ({ value }) => (
       <div className="my-4">
@@ -88,7 +84,7 @@ export function RichText<T>({ richText, className }: { richText?: T | null; clas
   return (
     <div
       className={cn(
-        "prose prose-slate prose-headings:scroll-m-24 prose-headings:font-bold prose-headings:text-opacity-90 prose-p:text-opacity-80 prose-a:underline prose-a:decoration-dotted prose-ol:list-decimal prose-ol:text-opacity-80 prose-ul:list-disc prose-ul:text-opacity-80 prose-h2:border-b prose-h2:pb-2 prose-h2:text-3xl prose-h2:font-semibold prose-h2:first:mt-0 max-w-none dark:prose-invert",
+        "prose prose-zinc prose-headings:scroll-m-24 prose-headings:text-opacity-90 prose-p:text-opacity-80 prose-a:decoration-dotted prose-ol:text-opacity-80 prose-ul:text-opacity-80 prose-h2:border-b prose-h2:pb-2 prose-h2:text-3xl prose-h2:font-semibold prose-h2:first:mt-0 max-w-none dark:prose-invert",
         className,
       )}
     >


### PR DESCRIPTION
This removes unneeded code/classes in the rich text component. By default headings in prose are bold so there's no need for `prose-headings:font-bold`. Furthermore, `prose-a:underline` is also the default for links in prose content and I switched `prose-slate` to `prose-zinc` since that is the [base color](https://github.com/robotostudio/turbo-start-sanity/blob/main/apps/web/components.json#L9) in `components.json`.  I also removed the `prose-ol:list-decimal` and `prose-ul:list-disc` as those are the default behavior in `prose`.

Oh and I also removed

```tsx
list: {
  bullet: ({ children }) => <ul>{children}</ul>,
  number: ({ children }) => <ol>{children}</ol>,
},
```

As it's not really adding any value as `prose` already wraps bullet lists with a `<ul />` and number lists with `<ol />`.