### PR TITLE
Use selected blog from blogIndex

### DIFF
--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -45,8 +45,10 @@ export default async function BlogIndexPage() {
     );
   }
 
-  // Extract featured blog and remaining blogs
-  const [featuredBlog, ...remainingBlogs] = blogs;
+  // Get featured blog from data.featured or first blog in array
+  const featuredBlog = data.featured || blogs[0];
+  // Get remaining blogs, filtering out the featured blog if it exists
+  const remainingBlogs = blogs.filter((blog) => blog._id !== featuredBlog?._id);
 
   return (
     <main className="bg-background">

--- a/apps/web/src/lib/sanity/query.ts
+++ b/apps/web/src/lib/sanity/query.ts
@@ -184,6 +184,9 @@ export const querySlugPagePaths = defineQuery(/* groq */ `
 export const queryBlogIndexPageData = defineQuery(/* groq */ `
   *[_type == "blogIndex"][0]{
     ...,
+    "featured": featured[0]->{
+      ${blogCardFragment}
+    },
     _id,
     _type,
     title,


### PR DESCRIPTION
I just so happened to notice the featured blog post on the Blog index page was not reflecting the selected blog post from the blogIndex schema. This update uses that blog post if selected, otherwise falls back to the first blog post.