### PR TITLE
feat: add media attribute to image fields in schema and update SEO metadata handling

### DIFF
--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -936,6 +936,13 @@
                       },
                       "optional": true
                     },
+                    "media": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "unknown"
+                      },
+                      "optional": true
+                    },
                     "hotspot": {
                       "type": "objectAttribute",
                       "value": {
@@ -1059,6 +1066,13 @@
                             }
                           },
                           "dereferencesTo": "sanity.imageAsset"
+                        },
+                        "optional": true
+                      },
+                      "media": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "unknown"
                         },
                         "optional": true
                       },
@@ -1898,6 +1912,13 @@
                       },
                       "optional": true
                     },
+                    "media": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "unknown"
+                      },
+                      "optional": true
+                    },
                     "hotspot": {
                       "type": "objectAttribute",
                       "value": {
@@ -2207,6 +2228,13 @@
                       },
                       "optional": true
                     },
+                    "media": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "unknown"
+                      },
+                      "optional": true
+                    },
                     "hotspot": {
                       "type": "objectAttribute",
                       "value": {
@@ -2287,6 +2315,13 @@
                     }
                   },
                   "dereferencesTo": "sanity.imageAsset"
+                },
+                "optional": true
+              },
+              "media": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "unknown"
                 },
                 "optional": true
               },
@@ -2707,6 +2742,13 @@
                     }
                   },
                   "dereferencesTo": "sanity.imageAsset"
+                },
+                "optional": true
+              },
+              "media": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "unknown"
                 },
                 "optional": true
               },
@@ -3187,6 +3229,13 @@
               },
               "optional": true
             },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
             "hotspot": {
               "type": "objectAttribute",
               "value": {
@@ -3419,6 +3468,13 @@
               },
               "optional": true
             },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
             "hotspot": {
               "type": "objectAttribute",
               "value": {
@@ -3576,6 +3632,13 @@
               },
               "optional": true
             },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
             "hotspot": {
               "type": "objectAttribute",
               "value": {
@@ -3700,6 +3763,13 @@
                   }
                 },
                 "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
               },
               "optional": true
             },
@@ -3883,6 +3953,13 @@
               },
               "optional": true
             },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
             "hotspot": {
               "type": "objectAttribute",
               "value": {
@@ -3964,6 +4041,13 @@
                   }
                 },
                 "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
               },
               "optional": true
             },
@@ -4167,6 +4251,13 @@
               },
               "optional": true
             },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
             "hotspot": {
               "type": "objectAttribute",
               "value": {
@@ -4248,6 +4339,13 @@
                   }
                 },
                 "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
               },
               "optional": true
             },

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -34,8 +34,7 @@ export async function generateMetadata({
 }) {
   const { slug } = await params;
   const { data } = await fetchBlogSlugPageData(slug);
-  if (!data) return getMetaData({});
-  return getMetaData(data);
+  return await getMetaData(data ?? {});
 }
 
 export async function generateStaticParams() {

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -13,8 +13,7 @@ async function fetchBlogPosts() {
 
 export async function generateMetadata() {
   const result = await sanityFetch({ query: queryBlogIndexPageData });
-  if (!result?.data) return getMetaData({});
-  return getMetaData(result.data);
+  return await getMetaData(result?.data ?? {});
 }
 
 export default async function BlogIndexPage() {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,10 +11,7 @@ async function fetchHomePageData() {
 
 export async function generateMetadata() {
   const homePageData = await fetchHomePageData();
-  if (!homePageData.data) {
-    return getMetaData({});
-  }
-  return await getMetaData(homePageData.data);
+  return await getMetaData(homePageData?.data ?? {});
 }
 
 export default async function Page() {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata() {
   if (!homePageData.data) {
     return getMetaData({});
   }
-  return getMetaData(homePageData.data);
+  return await getMetaData(homePageData.data);
 }
 
 export default async function Page() {

--- a/apps/web/src/lib/sanity/query.ts
+++ b/apps/web/src/lib/sanity/query.ts
@@ -159,7 +159,7 @@ const pageBuilderFragment = /* groq */ `
 `;
 
 export const queryHomePageData =
-  defineQuery(/* groq */ `*[_type == "homePage" && _id == "homePage"][0]{
+  defineQuery(`*[_type == "homePage" && _id == "homePage"][0]{
     ...,
     _id,
     _type,
@@ -169,7 +169,7 @@ export const queryHomePageData =
     ${pageBuilderFragment}
   }`);
 
-export const querySlugPageData = defineQuery(/* groq */ `
+export const querySlugPageData = defineQuery(`
   *[_type == "page" && slug.current == $slug][0]{
     ...,
     "slug": slug.current,
@@ -177,11 +177,11 @@ export const querySlugPageData = defineQuery(/* groq */ `
   }
   `);
 
-export const querySlugPagePaths = defineQuery(/* groq */ `
+export const querySlugPagePaths = defineQuery(`
   *[_type == "page" && defined(slug.current)].slug.current
 `);
 
-export const queryBlogIndexPageData = defineQuery(/* groq */ `
+export const queryBlogIndexPageData = defineQuery(`
   *[_type == "blogIndex"][0]{
     ...,
     _id,
@@ -198,7 +198,7 @@ export const queryBlogIndexPageData = defineQuery(/* groq */ `
   }
 `);
 
-export const queryBlogSlugPageData = defineQuery(/* groq */ `
+export const queryBlogSlugPageData = defineQuery(`
   *[_type == "blog" && slug.current == $slug][0]{
     ...,
     "slug": slug.current,
@@ -233,31 +233,31 @@ const ogFieldsFragment = /* groq */ `
   "date": coalesce(date, _createdAt)
 `;
 
-export const queryHomePageOGData = defineQuery(/* groq */ `
+export const queryHomePageOGData = defineQuery(`
   *[_type == "homePage" && _id == $id][0]{
     ${ogFieldsFragment}
   }
   `);
 
-export const querySlugPageOGData = defineQuery(/* groq */ `
+export const querySlugPageOGData = defineQuery(`
   *[_type == "page" && _id == $id][0]{
     ${ogFieldsFragment}
   }
 `);
 
-export const queryBlogPageOGData = defineQuery(/* groq */ `
+export const queryBlogPageOGData = defineQuery(`
   *[_type == "blog" && _id == $id][0]{
     ${ogFieldsFragment}
   }
 `);
 
-export const queryGenericPageOGData = defineQuery(/* groq */ `
+export const queryGenericPageOGData = defineQuery(`
   *[ defined(slug.current) && _id == $id][0]{
     ${ogFieldsFragment}
   }
 `);
 
-export const queryFooterData = defineQuery(/* groq */ `
+export const queryFooterData = defineQuery(`
   *[_type == "footer" && _id == "footer"][0]{
     _id,
     subtitle,
@@ -281,7 +281,7 @@ export const queryFooterData = defineQuery(/* groq */ `
   }
 `);
 
-export const queryNavbarData = defineQuery(/* groq */ `
+export const queryNavbarData = defineQuery(`
   *[_type == "navbar" && _id == "navbar"][0]{
     _id,
     columns[]{
@@ -320,7 +320,7 @@ export const queryNavbarData = defineQuery(/* groq */ `
   }
 `);
 
-export const querySitemapData = defineQuery(/* groq */ `{
+export const querySitemapData = defineQuery(`{
   "slugPages": *[_type == "page" && defined(slug.current)]{
     "slug": slug.current,
     "lastModified": _updatedAt
@@ -330,3 +330,19 @@ export const querySitemapData = defineQuery(/* groq */ `{
     "lastModified": _updatedAt
   }
 }`);
+
+export const queryGlobalSeoSettings = defineQuery(`
+  *[_type == "settings"][0]{
+    _id,
+    _type,
+    siteTitle,
+    siteDescription,
+    socialLinks{
+      linkedin,
+      facebook,
+      twitter,
+      instagram,
+      youtube
+    }
+  }
+`);

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -139,6 +139,7 @@ export type ImageLinkCards = {
           _weak?: boolean;
           [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
         };
+        media?: unknown;
         hotspot?: SanityImageHotspot;
         crop?: SanityImageCrop;
         caption?: string;
@@ -161,6 +162,7 @@ export type ImageLinkCards = {
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
       };
+      media?: unknown;
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       _type: "image";
@@ -268,6 +270,7 @@ export type Cta = {
           _weak?: boolean;
           [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
         };
+        media?: unknown;
         hotspot?: SanityImageHotspot;
         crop?: SanityImageCrop;
         caption?: string;
@@ -312,6 +315,7 @@ export type Hero = {
           _weak?: boolean;
           [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
         };
+        media?: unknown;
         hotspot?: SanityImageHotspot;
         crop?: SanityImageCrop;
         caption?: string;
@@ -326,6 +330,7 @@ export type Hero = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -391,6 +396,7 @@ export type RichText = Array<
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
       };
+      media?: unknown;
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       caption?: string;
@@ -471,6 +477,7 @@ export type Settings = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -506,6 +513,7 @@ export type BlogIndex = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -533,6 +541,7 @@ export type HomePage = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -556,6 +565,7 @@ export type Author = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -589,6 +599,7 @@ export type Page = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -603,6 +614,7 @@ export type Page = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -637,6 +649,7 @@ export type Blog = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -651,6 +664,7 @@ export type Blog = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -1001,6 +1015,7 @@ export type QueryHomePageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -1070,6 +1085,7 @@ export type QueryHomePageDataResult = {
                   _weak?: boolean;
                   [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
                 };
+                media?: unknown;
                 hotspot?: SanityImageHotspot;
                 crop?: SanityImageCrop;
                 caption?: string;
@@ -1168,6 +1184,7 @@ export type QueryHomePageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -1183,6 +1200,7 @@ export type QueryHomePageDataResult = {
             _weak?: boolean;
             [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
           };
+          media?: unknown;
           hotspot?: SanityImageHotspot;
           crop?: SanityImageCrop;
           _type: "image";
@@ -1239,6 +1257,7 @@ export type QueryHomePageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -1265,6 +1284,7 @@ export type QueryHomePageDataResult = {
               _weak?: boolean;
               [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
             };
+            media?: unknown;
             hotspot?: SanityImageHotspot;
             crop?: SanityImageCrop;
             _type: "image";
@@ -1348,6 +1368,7 @@ export type QueryHomePageDataResult = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -1373,6 +1394,7 @@ export type QuerySlugPageDataResult = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -1418,6 +1440,7 @@ export type QuerySlugPageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -1487,6 +1510,7 @@ export type QuerySlugPageDataResult = {
                   _weak?: boolean;
                   [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
                 };
+                media?: unknown;
                 hotspot?: SanityImageHotspot;
                 crop?: SanityImageCrop;
                 caption?: string;
@@ -1585,6 +1609,7 @@ export type QuerySlugPageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -1600,6 +1625,7 @@ export type QuerySlugPageDataResult = {
             _weak?: boolean;
             [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
           };
+          media?: unknown;
           hotspot?: SanityImageHotspot;
           crop?: SanityImageCrop;
           _type: "image";
@@ -1656,6 +1682,7 @@ export type QuerySlugPageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -1682,6 +1709,7 @@ export type QuerySlugPageDataResult = {
               _weak?: boolean;
               [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
             };
+            media?: unknown;
             hotspot?: SanityImageHotspot;
             crop?: SanityImageCrop;
             _type: "image";
@@ -1765,6 +1793,7 @@ export type QuerySlugPageDataResult = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -1830,6 +1859,7 @@ export type QueryBlogIndexPageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -1899,6 +1929,7 @@ export type QueryBlogIndexPageDataResult = {
                   _weak?: boolean;
                   [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
                 };
+                media?: unknown;
                 hotspot?: SanityImageHotspot;
                 crop?: SanityImageCrop;
                 caption?: string;
@@ -1997,6 +2028,7 @@ export type QueryBlogIndexPageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -2012,6 +2044,7 @@ export type QueryBlogIndexPageDataResult = {
             _weak?: boolean;
             [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
           };
+          media?: unknown;
           hotspot?: SanityImageHotspot;
           crop?: SanityImageCrop;
           _type: "image";
@@ -2068,6 +2101,7 @@ export type QueryBlogIndexPageDataResult = {
                 _weak?: boolean;
                 [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
               };
+              media?: unknown;
               hotspot?: SanityImageHotspot;
               crop?: SanityImageCrop;
               caption?: string;
@@ -2094,6 +2128,7 @@ export type QueryBlogIndexPageDataResult = {
               _weak?: boolean;
               [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
             };
+            media?: unknown;
             hotspot?: SanityImageHotspot;
             crop?: SanityImageCrop;
             _type: "image";
@@ -2177,6 +2212,7 @@ export type QueryBlogIndexPageDataResult = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -2198,6 +2234,7 @@ export type QueryBlogIndexPageDataResult = {
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
       };
+      media?: unknown;
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       _type: "image";
@@ -2217,6 +2254,7 @@ export type QueryBlogIndexPageDataResult = {
           _weak?: boolean;
           [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
         };
+        media?: unknown;
         hotspot?: SanityImageHotspot;
         crop?: SanityImageCrop;
         _type: "image";
@@ -2250,6 +2288,7 @@ export type QueryBlogSlugPageDataResult = {
         _weak?: boolean;
         [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
       };
+      media?: unknown;
       hotspot?: SanityImageHotspot;
       crop?: SanityImageCrop;
       _type: "image";
@@ -2266,6 +2305,7 @@ export type QueryBlogSlugPageDataResult = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -2308,6 +2348,7 @@ export type QueryBlogSlugPageDataResult = {
           _weak?: boolean;
           [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
         };
+        media?: unknown;
         hotspot?: SanityImageHotspot;
         crop?: SanityImageCrop;
         caption?: string;
@@ -2325,6 +2366,7 @@ export type QueryBlogSlugPageDataResult = {
       _weak?: boolean;
       [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
     };
+    media?: unknown;
     hotspot?: SanityImageHotspot;
     crop?: SanityImageCrop;
     _type: "image";
@@ -2500,6 +2542,21 @@ export type QuerySitemapDataResult = {
     lastModified: string;
   }>;
 };
+// Variable: queryGlobalSeoSettings
+// Query: *[_type == "settings"][0]{    _id,    _type,    siteTitle,    siteDescription,    socialLinks{      linkedin,      facebook,      twitter,      instagram,      youtube    }  }
+export type QueryGlobalSeoSettingsResult = {
+  _id: string;
+  _type: "settings";
+  siteTitle: string;
+  siteDescription: string;
+  socialLinks: {
+    linkedin: string | null;
+    facebook: string | null;
+    twitter: string | null;
+    instagram: string | null;
+    youtube: string | null;
+  } | null;
+} | null;
 
 // Query TypeMap
 import "@sanity/client";
@@ -2518,5 +2575,6 @@ declare module "@sanity/client" {
     '\n  *[_type == "footer" && _id == "footer"][0]{\n    _id,\n    subtitle,\n    columns[]{\n      _key,\n      title,\n      links[]{\n        _key,\n        name,\n        "openInNewTab": url.openInNewTab,\n        "href": select(\n          url.type == "internal" => url.internal->slug.current,\n          url.type == "external" => url.external,\n          url.href\n        ),\n      }\n    },\n    "logo": *[_type == "settings"][0].logo.asset->url + "?w=80&h=40&dpr=3&fit=max",\n    "siteTitle": *[_type == "settings"][0].siteTitle,\n    "socialLinks": *[_type == "settings"][0].socialLinks,\n  }\n': QueryFooterDataResult;
     '\n  *[_type == "navbar" && _id == "navbar"][0]{\n    _id,\n    columns[]{\n      _key,\n      _type == "navbarColumn" => {\n        "type": "column",\n        title,\n        links[]{\n          _key,\n          name,\n          icon,\n          description,\n          "openInNewTab": url.openInNewTab,\n          "href": select(\n            url.type == "internal" => url.internal->slug.current,\n            url.type == "external" => url.external,\n            url.href\n          )\n        }\n      },\n      _type == "navbarLink" => {\n        "type": "link",\n        name,\n        description,\n        "openInNewTab": url.openInNewTab,\n        "href": select(\n          url.type == "internal" => url.internal->slug.current,\n          url.type == "external" => url.external,\n          url.href\n        )\n      }\n    },\n    \n  buttons[]{\n    text,\n    variant,\n    _key,\n    _type,\n    "openInNewTab": url.openInNewTab,\n    "href": select(\n      url.type == "internal" => url.internal->slug.current,\n      url.type == "external" => url.external,\n      url.href\n    ),\n  }\n,\n    "logo": *[_type == "settings"][0].logo.asset->url + "?w=80&h=40&dpr=3&fit=max",\n    "siteTitle": *[_type == "settings"][0].siteTitle,\n  }\n': QueryNavbarDataResult;
     '{\n  "slugPages": *[_type == "page" && defined(slug.current)]{\n    "slug": slug.current,\n    "lastModified": _updatedAt\n  },\n  "blogPages": *[_type == "blog" && defined(slug.current)]{\n    "slug": slug.current,\n    "lastModified": _updatedAt\n  }\n}': QuerySitemapDataResult;
+    '\n  *[_type == "settings"][0]{\n    _id,\n    _type,\n    siteTitle,\n    siteDescription,\n    socialLinks{\n      linkedin,\n      facebook,\n      twitter,\n      instagram,\n      youtube\n    }\n  }\n': QueryGlobalSeoSettingsResult;
   }
 }

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import type { Maybe } from "@/types";
 import { capitalize } from "@/utils";
 
 import { getBaseUrl } from "../config";
@@ -7,13 +8,13 @@ import { client } from "./sanity/client";
 import { queryGlobalSeoSettings } from "./sanity/query";
 
 interface MetaDataInput {
-  _type?: string;
-  _id?: string;
-  seoTitle?: string;
-  seoDescription?: string;
-  title?: string;
-  description?: string;
-  slug?: string | { current: string };
+  _type?: Maybe<string>;
+  _id?: Maybe<string>;
+  seoTitle?: Maybe<string>;
+  seoDescription?: Maybe<string>;
+  title?: Maybe<string>;
+  description?: Maybe<string>;
+  slug?: Maybe<string> | { current: Maybe<string> };
 }
 
 function getOgImage({ type, id }: { type?: string; id?: string } = {}): string {
@@ -24,7 +25,7 @@ function getOgImage({ type, id }: { type?: string; id?: string } = {}): string {
   return `${baseUrl}/api/og?${params.toString()}`;
 }
 
-export async function getMetaData(data: MetaDataInput): Promise<Metadata> {
+export async function getMetaData(data: MetaDataInput = {}): Promise<Metadata> {
   const { _type, seoDescription, seoTitle, slug, title, description, _id } =
     data ?? {};
 

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,43 +1,50 @@
 import type { Metadata } from "next";
 
-import { getBaseUrl } from "@/config";
-import type { Maybe } from "@/types";
+import { capitalize } from "@/utils";
 
-interface OgImageOptions {
-  type?: string;
-  id?: string;
+import { getBaseUrl } from "../config";
+import { client } from "./sanity/client";
+import { queryGlobalSeoSettings } from "./sanity/query";
+
+interface MetaDataInput {
+  _type?: string;
+  _id?: string;
+  seoTitle?: string;
+  seoDescription?: string;
+  title?: string;
+  description?: string;
+  slug?: string | { current: string };
 }
 
-function getOgImage({ type, id }: OgImageOptions = {}): string {
+function getOgImage({ type, id }: { type?: string; id?: string } = {}): string {
   const params = new URLSearchParams();
   if (id) params.set("id", id);
   if (type) params.set("type", type);
   const baseUrl = getBaseUrl();
-  const logoUrl = `${baseUrl}/api/og?${params.toString()}`;
-  return logoUrl;
+  return `${baseUrl}/api/og?${params.toString()}`;
 }
 
-interface MetaDataInput {
-  _type?: Maybe<string>;
-  seoDescription?: Maybe<string>;
-  seoTitle?: Maybe<string>;
-  slug?: Maybe<{ current: string | null }> | string | null;
-  title?: Maybe<string>;
-  description?: Maybe<string>;
-  _id?: Maybe<string>;
-}
-
-export function getMetaData(data: MetaDataInput): Metadata {
+export async function getMetaData(data: MetaDataInput): Promise<Metadata> {
   const { _type, seoDescription, seoTitle, slug, title, description, _id } =
     data ?? {};
+
+  // Fetch global SEO settings
+  const globalSettings = await client.fetch(queryGlobalSeoSettings);
+  const { siteTitle, siteDescription, socialLinks } = globalSettings || {};
 
   const baseUrl = getBaseUrl();
   const pageSlug = typeof slug === "string" ? slug : (slug?.current ?? "");
   const pageUrl = `${baseUrl}${pageSlug}`;
 
+  const placeholderTitle = capitalize(pageSlug);
+
+  const twitterHandle = socialLinks?.twitter
+    ? `@${socialLinks.twitter.split("/").pop()}`
+    : "@studioroboto";
+
   const meta = {
-    title: seoTitle ?? title ?? "",
-    description: seoDescription ?? description ?? "",
+    title: `${seoTitle ?? title ?? placeholderTitle}`,
+    description: seoDescription ?? description ?? siteDescription ?? "",
   };
 
   const ogImage = getOgImage({
@@ -45,12 +52,15 @@ export function getMetaData(data: MetaDataInput): Metadata {
     id: _id ?? undefined,
   });
 
+  // Use siteTitle from settings for branding, with a fallback only if settings are not available
+  const brandName = siteTitle || "Roboto Studio Demo";
+
   return {
-    title: `${meta.title} | Roboto Studio Demo`,
+    title: `${meta.title} | ${brandName}`,
     description: meta.description,
     metadataBase: new URL(baseUrl),
-    creator: "Roboto Studio Demo",
-    authors: [{ name: "Roboto" }],
+    creator: brandName,
+    authors: [{ name: brandName }],
     icons: {
       icon: `${baseUrl}/favicon.ico`,
     },
@@ -66,7 +76,7 @@ export function getMetaData(data: MetaDataInput): Metadata {
     twitter: {
       card: "summary_large_image",
       images: [ogImage],
-      creator: "@studioroboto",
+      creator: twitterHandle,
       title: meta.title,
       description: meta.description,
     },


### PR DESCRIPTION
- Introduced a new optional `media` attribute to various image fields in the schema to enhance media handling capabilities.
- Updated the `getMetaData` function to fetch global SEO settings, improving metadata generation for pages.
- Refactored metadata handling to ensure consistent branding and fallback mechanisms for titles and descriptions.

## Description

<!-- Brief description of changes -->

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation

## Screenshots (if applicable)

<!-- Screenshots of visual changes -->

## Testing

<!-- How were these changes tested? -->

## Related issues

<!-- Reference any related issues (e.g., Fixes #123) -->
