### PR TITLE
fix: updates eslint config to exclude Next output directories

### DIFF
--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -21,7 +21,7 @@ export const nextJsConfig = [
   js.configs.recommended,
   eslintConfigPrettier,
   ...tseslint.configs.recommended,
-  { ignores: [".next"] },
+  { ignores: [".next", "out", "build", "dist"] },
   {
     ...pluginReact.configs.flat.recommended,
     languageOptions: {


### PR DESCRIPTION
## Description

Updates `next-js` eslint rules to exclude Next JS output directories (e.g., `apps/web/.next`).

## Detail

If you try to bootstrap a new project using Turbo Start Sanity, then try to lint `apps/web`, the command hangs indefinitely. After inspecting the config (see Testing section below), I found eslint trying to process `.next`. 😨 

Suggestion: it may be worth setting up an `inspectEslint` task for easier testing in the future. I can add that if it's desired.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation

## Screenshots (if applicable)

Before:

<img width="963" alt="Screenshot 2025-05-23 at 9 57 30 PM" src="https://github.com/user-attachments/assets/add47d87-e30e-4025-baf9-d2f55a5e419d" />
<img width="945" alt="Screenshot 2025-05-24 at 10 10 37 AM" src="https://github.com/user-attachments/assets/30f5a58a-4cbb-4041-9556-578e21ef399a" />


After:

<img width="971" alt="Screenshot 2025-05-23 at 9 56 59 PM" src="https://github.com/user-attachments/assets/84dc195e-d515-41aa-883a-c48fa7a3ad98" />
<img width="810" alt="Screenshot 2025-05-24 at 10 17 55 AM" src="https://github.com/user-attachments/assets/2647a948-5a05-4f40-b768-34e870399aef" />

## Testing

1. In a fresh install of the template, run `pnpm run lint`
2. Cancel the command (it will hang)
3. Run `cd apps/web && pnpx eslint --inspect-config` to see eslint file paths
4. Cancel the command and apply the changes of this PR
5. Rerun command from step 3
6. Observe updated file paths (all other expected paths should be preserved)

## Related issues

N/A
