### PR TITLE
docs: update README and CLI alert for data import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Your content should now appear in your Next.js app ([http://localhost:3000](http
 
 #### 2. Sample Content
 
-When you initialize the template using the Sanity CLI, sample content is automatically imported into your project. This includes example blog posts, authors, and other content types to help you get started quickly.
+When you initialize the template using the Sanity CLI, sample content is not automatically imported into your project. However, you can import it after the init is done. This data includes example blog posts, authors, and other content types to help you get started quickly (see next step).
 
 #### 3. Seed data using script
 
@@ -79,7 +79,7 @@ To add sample data programmatically, run the following command:
 
 ```shell
 cd apps/studio
-sanity exec scripts/create-data.ts --with-user-token
+npx sanity exec scripts/create-data.ts --with-user-token
 ```
 
 This command executes a TypeScript script that creates and populates content in your Sanity dataset.

--- a/apps/studio/scripts/cli-alert-for-data.ts
+++ b/apps/studio/scripts/cli-alert-for-data.ts
@@ -24,7 +24,7 @@ async function main() {
     "\x1b[34m└────────────────────────────────────────────────────────────────────────────┘\x1b[0m\n",
   );
   console.log(
-    "\x1b[34m cd apps/studio && sanity exec scripts/create-data.ts --with-user-token    \x1b[0m",
+    "\x1b[34m cd apps/studio && npx sanity exec scripts/create-data.ts --with-user-token    \x1b[0m",
   );
 }
 


### PR DESCRIPTION
- Clarified that sample content is not automatically imported with the Sanity CLI initialization, but can be imported afterward.
- Updated command in the CLI alert to use `npx` for executing the data creation script.

## Description

When I used the template it prompted me to run the command for seeding, which did not work. I've updated both the prompt and the readme to the command that did work for me. 

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Documentation
