### PR TITLE
docs: update README and CLI alert for deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The schemas for all document types are defined in the `studio/schemaTypes/docume
 
 Your Next.js frontend (`/web`) and Sanity Studio (`/studio`) are still only running on your local computer. It's time to deploy and get it into the hands of other content editors.
 
+> **⚠️ Important**: When initializing the template with the Sanity CLI, the `.github` folder may not be included or might be renamed to `github` (without the dot). If you don't see a `.github` folder in your project root, you'll need to manually create it and copy the GitHub Actions workflows from the [template repository](https://github.com/robotostudio/turbo-start-sanity/tree/main/.github) for the deployment automation to work.
+
 The template includes a GitHub Actions workflow [`deploy-sanity.yml`](https://raw.githubusercontent.com/robotostudio/turbo-start-sanity/main/.github/workflows/deploy-sanity.yml) that automatically deploys your Sanity Studio whenever changes are pushed to the `studio` directory.
 
 > **Note**: To use the GitHub Actions workflow, make sure to configure the following secrets in your repository settings:

--- a/apps/studio/scripts/cli-alert-for-data.ts
+++ b/apps/studio/scripts/cli-alert-for-data.ts
@@ -26,6 +26,7 @@ async function main() {
   console.log(
     "\x1b[34m cd apps/studio && npx sanity exec scripts/create-data.ts --with-user-token    \x1b[0m",
   );
+  console.log("\x1b[34m mv github .github for actions to work  \x1b[0m");
 }
 
 main();

--- a/github/dependabot.yml
+++ b/github/dependabot.yml
@@ -1,0 +1,10 @@
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/github/workflows/deploy-sanity.yml
+++ b/github/workflows/deploy-sanity.yml
@@ -1,0 +1,74 @@
+name: Deploy Sanity Studio
+on:
+  push:
+    paths:
+      - "apps/studio/**"
+      - ".github/workflows/deploy-sanity.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: Build and Deploy Sanity Studio
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SANITY_AUTH_TOKEN: ${{ secrets.SANITY_DEPLOY_TOKEN }}
+      NODE_OPTIONS: "--max_old_space_size=4096"
+      PNPM_VERSION: 9.12.3
+      SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
+      SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET }}
+      SANITY_STUDIO_TITLE: ${{ secrets.SANITY_STUDIO_TITLE }}
+      SANITY_STUDIO_PRESENTATION_URL: ${{ secrets.SANITY_STUDIO_PRESENTATION_URL }}
+      HOST_NAME: ${{ github.head_ref || github.ref_name }}  
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts --prefer-offline
+        
+      - name: Check if Dependabot
+        id: check-dependabot
+        run: |
+          if [[ ${{ github.actor }} == 'dependabot[bot]' ]]; then
+            echo "is_dependabot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_dependabot=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Sanity Studio (Dependabot)
+        if: steps.check-dependabot.outputs.is_dependabot == 'true'
+        working-directory: ./apps/studio
+        run: |
+          echo "Building Sanity Studio for Dependabot..."
+          pnpm run build
+        env:
+          CI: true
+        
+      - name: Deploy Sanity Studio
+        if: steps.check-dependabot.outputs.is_dependabot != 'true'
+        working-directory: ./apps/studio
+        run: |
+          echo "Deploying Sanity Studio..."
+          pnpm run deploy
+        env:
+          CI: true


### PR DESCRIPTION
- Added a note regarding the potential absence or renaming of the `.github` folder during Sanity CLI initialization, emphasizing the need for manual creation and copying of GitHub Actions workflows.
- Updated CLI alert script to inform users to rename the `github` folder to `.github` for actions to function correctly.
- Introduced a new `dependabot.yml` file to enable automated dependency updates for npm packages.
- Created a `deploy-sanity.yml` GitHub Actions workflow for automated deployment of the Sanity Studio upon changes in the `apps/studio` directory.

## Description

<!-- Brief description of changes -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Documentation

## Screenshots (if applicable)

<!-- Screenshots of visual changes -->

## Testing

<!-- How were these changes tested? -->

## Related issues

<!-- Reference any related issues (e.g., Fixes #123) -->
