### PR TITLE
refactor: update fetch functions to accept 'stega' parameter

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -6,10 +6,11 @@ import { sanityFetch } from "@/lib/sanity/live";
 import { querySlugPageData, querySlugPagePaths } from "@/lib/sanity/query";
 import { getMetaData } from "@/lib/seo";
 
-async function fetchSlugPageData(slug: string) {
+async function fetchSlugPageData(slug: string, stega = true) {
   return await sanityFetch({
     query: querySlugPageData,
     params: { slug: `/${slug}` },
+    stega,
   });
 }
 
@@ -31,7 +32,7 @@ export async function generateMetadata({
 }) {
   const { slug } = await params;
   const slugString = slug.join("/");
-  const { data: pageData } = await fetchSlugPageData(slugString);
+  const { data: pageData } = await fetchSlugPageData(slugString, false);
   if (!pageData) {
     return getMetaData({});
   }

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -9,10 +9,11 @@ import { sanityFetch } from "@/lib/sanity/live";
 import { queryBlogPaths, queryBlogSlugPageData } from "@/lib/sanity/query";
 import { getMetaData } from "@/lib/seo";
 
-async function fetchBlogSlugPageData(slug: string) {
+async function fetchBlogSlugPageData(slug: string, stega = true) {
   return await sanityFetch({
     query: queryBlogSlugPageData,
     params: { slug: `/blog/${slug}` },
+    stega,
   });
 }
 
@@ -33,7 +34,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const { data } = await fetchBlogSlugPageData(slug);
+  const { data } = await fetchBlogSlugPageData(slug, false);
   return await getMetaData(data ?? {});
 }
 

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -12,7 +12,10 @@ async function fetchBlogPosts() {
 }
 
 export async function generateMetadata() {
-  const result = await sanityFetch({ query: queryBlogIndexPageData });
+  const result = await sanityFetch({
+    query: queryBlogIndexPageData,
+    stega: false,
+  });
   return await getMetaData(result?.data ?? {});
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,14 +3,15 @@ import { sanityFetch } from "@/lib/sanity/live";
 import { queryHomePageData } from "@/lib/sanity/query";
 import { getMetaData } from "@/lib/seo";
 
-async function fetchHomePageData() {
+async function fetchHomePageData(stega = true) {
   return await sanityFetch({
     query: queryHomePageData,
+    stega,
   });
 }
 
 export async function generateMetadata() {
-  const homePageData = await fetchHomePageData();
+  const homePageData = await fetchHomePageData(false);
   return await getMetaData(homePageData?.data ?? {});
 }
 


### PR DESCRIPTION
- Modified fetch functions in home, slug, blog, and blog slug pages to include a 'stega' parameter, defaulting to true.
- Updated calls to these functions in generateMetadata to explicitly pass 'false' for 'stega', ensuring consistent behavior across data fetching.

## Description

<!-- Brief description of changes -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Documentation

## Screenshots (if applicable)

<!-- Screenshots of visual changes -->

## Testing

<!-- How were these changes tested? -->

## Related issues

<!-- Reference any related issues (e.g., Fixes #123) -->
