### PR TITLE
refactor: update SEO metadata handling across page components

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -4,7 +4,7 @@ import { PageBuilder } from "@/components/pagebuilder";
 import { client } from "@/lib/sanity/client";
 import { sanityFetch } from "@/lib/sanity/live";
 import { querySlugPageData, querySlugPagePaths } from "@/lib/sanity/query";
-import { getMetaData } from "@/lib/seo";
+import { getSEOMetadata } from "@/lib/seo";
 
 async function fetchSlugPageData(slug: string, stega = true) {
   return await sanityFetch({
@@ -33,7 +33,17 @@ export async function generateMetadata({
   const { slug } = await params;
   const slugString = slug.join("/");
   const { data: pageData } = await fetchSlugPageData(slugString, false);
-  return getMetaData(pageData ?? {});
+  return getSEOMetadata(
+    pageData
+      ? {
+          title: pageData?.title ?? pageData?.seoTitle ?? "",
+          description: pageData?.description ?? pageData?.seoDescription ?? "",
+          slug: pageData?.slug,
+          contentId: pageData?._id,
+          contentType: pageData?._type,
+        }
+      : {},
+  );
 }
 
 export async function generateStaticParams() {

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { TableOfContent } from "@/components/table-of-content";
 import { client } from "@/lib/sanity/client";
 import { sanityFetch } from "@/lib/sanity/live";
 import { queryBlogPaths, queryBlogSlugPageData } from "@/lib/sanity/query";
-import { getMetaData } from "@/lib/seo";
+import { getSEOMetadata } from "@/lib/seo";
 
 async function fetchBlogSlugPageData(slug: string, stega = true) {
   return await sanityFetch({
@@ -36,7 +36,18 @@ export async function generateMetadata({
 }) {
   const { slug } = await params;
   const { data } = await fetchBlogSlugPageData(slug, false);
-  return await getMetaData(data ?? {});
+  return getSEOMetadata(
+    data
+      ? {
+          title: data?.title ?? data?.seoTitle ?? "",
+          description: data?.description ?? data?.seoDescription ?? "",
+          slug: data?.slug,
+          contentId: data?._id,
+          contentType: data?._type,
+          pageType: "article",
+        }
+      : {},
+  );
 }
 
 export async function generateStaticParams() {

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -4,7 +4,7 @@ import { BlogCard, BlogHeader, FeaturedBlogCard } from "@/components/blog-card";
 import { PageBuilder } from "@/components/pagebuilder";
 import { sanityFetch } from "@/lib/sanity/live";
 import { queryBlogIndexPageData } from "@/lib/sanity/query";
-import { getMetaData } from "@/lib/seo";
+import { getSEOMetadata } from "@/lib/seo";
 import { handleErrors } from "@/utils";
 
 async function fetchBlogPosts() {
@@ -12,11 +12,21 @@ async function fetchBlogPosts() {
 }
 
 export async function generateMetadata() {
-  const result = await sanityFetch({
+  const { data: result } = await sanityFetch({
     query: queryBlogIndexPageData,
     stega: false,
   });
-  return await getMetaData(result?.data ?? {});
+  return getSEOMetadata(
+    result
+      ? {
+          title: result?.title ?? result?.seoTitle ?? "",
+          description: result?.description ?? result?.seoDescription ?? "",
+          slug: result?.slug,
+          contentId: result?._id,
+          contentType: result?._type,
+        }
+      : {},
+  );
 }
 
 export default async function BlogIndexPage() {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { PageBuilder } from "@/components/pagebuilder";
 import { sanityFetch } from "@/lib/sanity/live";
 import { queryHomePageData } from "@/lib/sanity/query";
-import { getMetaData } from "@/lib/seo";
+import { getSEOMetadata } from "@/lib/seo";
 
 async function fetchHomePageData(stega = true) {
   return await sanityFetch({
@@ -11,8 +11,19 @@ async function fetchHomePageData(stega = true) {
 }
 
 export async function generateMetadata() {
-  const homePageData = await fetchHomePageData(false);
-  return await getMetaData(homePageData?.data ?? {});
+  const { data: homePageData } = await fetchHomePageData(false);
+  return getSEOMetadata(
+    homePageData
+      ? {
+          title: homePageData?.title ?? homePageData?.seoTitle ?? "",
+          description:
+            homePageData?.description ?? homePageData?.seoDescription ?? "",
+          slug: homePageData?.slug,
+          contentId: homePageData?._id,
+          contentType: homePageData?._type,
+        }
+      : {},
+  );
 }
 
 export default async function Page() {

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -4,101 +4,155 @@ import type { Maybe } from "@/types";
 import { capitalize } from "@/utils";
 
 import { getBaseUrl } from "../config";
-import { client } from "./sanity/client";
-import { queryGlobalSeoSettings } from "./sanity/query";
 
-interface MetaDataInput {
-  _type?: Maybe<string>;
-  _id?: Maybe<string>;
-  seoTitle?: Maybe<string>;
-  seoDescription?: Maybe<string>;
-  title?: Maybe<string>;
-  description?: Maybe<string>;
-  slug?: Maybe<string> | { current: Maybe<string> };
+// Site-wide configuration interface
+interface SiteConfig {
+  title: string;
+  description: string;
+  twitterHandle: string;
+  keywords: string[];
 }
 
-function getOgImage({ type, id }: { type?: string; id?: string } = {}): string {
-  const params = new URLSearchParams();
-  if (id) params.set("id", id);
-  if (type) params.set("type", type);
-  const baseUrl = getBaseUrl();
-  return `${baseUrl}/api/og?${params.toString()}`;
+// Page-specific SEO data interface
+interface PageSeoData extends Metadata {
+  title?: string;
+  description?: string;
+  slug?: string;
+  contentId?: string;
+  contentType?: string;
+  keywords?: string[];
+  seoNoIndex?: boolean;
+  pageType?: Extract<Metadata["openGraph"], { type: string }>["type"];
 }
 
-export async function getMetaData(data: MetaDataInput = {}): Promise<Metadata> {
-  const { _type, seoDescription, seoTitle, slug, title, description, _id } =
-    data ?? {};
+// OpenGraph image generation parameters
+interface OgImageParams {
+  type?: string;
+  id?: string;
+}
 
-  // Fetch global SEO settings
-  const globalSettings = await client.fetch(queryGlobalSeoSettings);
-  const { siteTitle, siteDescription, socialLinks } = globalSettings || {};
+// Default site configuration
+const siteConfig: SiteConfig = {
+  title: "Roboto Studio Demo",
+  description: "Roboto Studio Demo",
+  twitterHandle: "@studioroboto",
+  keywords: ["roboto", "studio", "demo", "sanity", "next", "react", "template"],
+};
+
+function generateOgImageUrl(params: OgImageParams = {}): string {
+  const { type, id } = params;
+  const searchParams = new URLSearchParams();
+
+  if (id) searchParams.set("id", id);
+  if (type) searchParams.set("type", type);
 
   const baseUrl = getBaseUrl();
-  const pageSlug = typeof slug === "string" ? slug : (slug?.current ?? "");
-  const pageUrl = `${baseUrl}${pageSlug}`;
+  return `${baseUrl}/api/og?${searchParams.toString()}`;
+}
 
-  const placeholderTitle = capitalize(pageSlug);
+function buildPageUrl({
+  baseUrl,
+  slug,
+}: {
+  baseUrl: string;
+  slug: string;
+}): string {
+  const normalizedSlug = slug.startsWith("/") ? slug : `/${slug}`;
+  return `${baseUrl}${normalizedSlug}`;
+}
 
-  const twitterHandle = socialLinks?.twitter
-    ? `@${socialLinks.twitter.split("/").pop()}`
-    : "@studioroboto";
+function extractTitle({
+  pageTitle,
+  slug,
+  siteTitle,
+}: {
+  pageTitle?: Maybe<string>;
+  slug: string;
+  siteTitle: string;
+}): string {
+  if (pageTitle) return pageTitle;
+  if (slug && slug !== "/") return capitalize(slug.replace(/^\//, ""));
+  return siteTitle;
+}
 
-  const meta = {
-    title: `${seoTitle ?? title ?? placeholderTitle}`,
-    description: seoDescription ?? description ?? siteDescription ?? "",
-  };
+export function getSEOMetadata(page: PageSeoData = {}): Metadata {
+  const {
+    title: pageTitle,
+    description: pageDescription,
+    slug = "/",
+    contentId,
+    contentType,
+    keywords: pageKeywords = [],
+    seoNoIndex = false,
+    pageType = "website",
+    ...pageOverrides
+  } = page;
 
-  const ogImage = getOgImage({
-    type: _type ?? undefined,
-    id: _id ?? undefined,
+  const baseUrl = getBaseUrl();
+  const pageUrl = buildPageUrl({ baseUrl, slug });
+
+  // Build default metadata values
+  const defaultTitle = extractTitle({
+    pageTitle,
+    slug,
+    siteTitle: siteConfig.title,
+  });
+  const defaultDescription = pageDescription || siteConfig.description;
+  const allKeywords = [...siteConfig.keywords, ...pageKeywords];
+
+  const ogImage = generateOgImageUrl({
+    type: contentType,
+    id: contentId,
   });
 
-  // Use siteTitle from settings for branding, with a fallback only if settings are not available
-  const brandName = siteTitle || "Roboto Studio Demo";
+  const fullTitle =
+    defaultTitle === siteConfig.title
+      ? defaultTitle
+      : `${defaultTitle} | ${siteConfig.title}`;
 
-  return {
-    title: `${meta.title} | ${brandName}`,
-    description: meta.description,
+  // Build default metadata object
+  const defaultMetadata: Metadata = {
+    title: fullTitle,
+    description: defaultDescription,
     metadataBase: new URL(baseUrl),
-    creator: brandName,
-    authors: [{ name: brandName }],
+    creator: siteConfig.title,
+    authors: [{ name: siteConfig.title }],
     icons: {
       icon: `${baseUrl}/favicon.ico`,
     },
-    keywords: [
-      "roboto",
-      "studio",
-      "demo",
-      "sanity",
-      "next",
-      "react",
-      "template",
-    ],
+    keywords: allKeywords,
+    robots: seoNoIndex ? "noindex, nofollow" : "index, follow",
     twitter: {
       card: "summary_large_image",
       images: [ogImage],
-      creator: twitterHandle,
-      title: meta.title,
-      description: meta.description,
+      creator: siteConfig.twitterHandle,
+      title: defaultTitle,
+      description: defaultDescription,
     },
     alternates: {
       canonical: pageUrl,
     },
     openGraph: {
-      type: "website",
+      type: pageType ?? "website",
       countryName: "UK",
-      description: meta.description,
-      title: meta.title,
+      description: defaultDescription,
+      title: defaultTitle,
       images: [
         {
           url: ogImage,
           width: 1200,
           height: 630,
-          alt: meta.title,
+          alt: defaultTitle,
           secureUrl: ogImage,
         },
       ],
       url: pageUrl,
     },
+  };
+
+  // Override any defaults with page-specific metadata
+  return {
+    ...defaultMetadata,
+    ...pageOverrides,
   };
 }


### PR DESCRIPTION
- Replaced `getMetaData` with `getSEOMetadata` in `page.tsx`, `blog/page.tsx`, and `blog/[slug]/page.tsx` to streamline SEO data extraction.
- Enhanced `generateMetadata` functions to utilize structured page data for improved SEO metadata generation.
- Updated the `seo.ts` file to define a new `getSEOMetadata` function, consolidating SEO logic and improving maintainability.

## Description

<!-- Brief description of changes -->

## Type of change

- [ ] Feature
- [x] Fix
- [x] Refactor
- [ ] Documentation

## Screenshots (if applicable)

<!-- Screenshots of visual changes -->

## Testing

<!-- How were these changes tested? -->

## Related issues

<!-- Reference any related issues (e.g., Fixes #123) -->
