### PR TITLE
feat: implement branch-based dataset selection to safeguard production data

### DIFF
--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -20,11 +20,11 @@ jobs:
       NODE_OPTIONS: "--max_old_space_size=4096"
       PNPM_VERSION: 10.12.2
       SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
-      SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET }}
+      SANITY_STUDIO_DATASET: ${{ github.ref_name == 'main' && secrets.SANITY_STUDIO_PRODUCTION_DATASET || secrets.SANITY_STUDIO_DEVELOPMENT_DATASET }}
       SANITY_STUDIO_TITLE: ${{ secrets.SANITY_STUDIO_TITLE }}
       SANITY_STUDIO_PRESENTATION_URL: ${{ secrets.SANITY_STUDIO_PRESENTATION_URL }}
       SANITY_STUDIO_PRODUCTION_HOSTNAME: ${{ secrets.SANITY_STUDIO_PRODUCTION_HOSTNAME }}
-      HOST_NAME: ${{ github.head_ref || github.ref_name }}  
+      HOST_NAME: ${{ github.head_ref || github.ref_name }}
 
     steps:
       - name: Checkout repository
@@ -42,11 +42,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts --prefer-offline
-        
+
       - name: Check if Dependabot
         id: check-dependabot
         run: |
@@ -64,7 +64,7 @@ jobs:
           pnpm run build
         env:
           CI: true
-        
+
       - name: Deploy Sanity Studio
         if: steps.check-dependabot.outputs.is_dependabot != 'true'
         working-directory: ./apps/studio

--- a/README.md
+++ b/README.md
@@ -98,11 +98,17 @@ Your Next.js frontend (`/web`) and Sanity Studio (`/studio`) are still only runn
 
 The template includes a GitHub Actions workflow [`deploy-sanity.yml`](https://raw.githubusercontent.com/robotostudio/turbo-start-sanity/main/.github/workflows/deploy-sanity.yml) that automatically deploys your Sanity Studio whenever changes are pushed to the `studio` directory.
 
+**🛡️ Safeguard**: The workflow uses branch-based dataset selection to safeguard your production data:
+
+- **`main` branch**: Deploys to production dataset
+- **All other branches**: Deploys to development dataset (feature branches, staging)
+
 > **Note**: To use the GitHub Actions workflow, make sure to configure the following secrets in your repository settings:
 >
 > - `SANITY_DEPLOY_TOKEN`
 > - `SANITY_STUDIO_PROJECT_ID`
-> - `SANITY_STUDIO_DATASET`
+> - `SANITY_STUDIO_PRODUCTION_DATASET` (for main branch deployments)
+> - `SANITY_STUDIO_DEVELOPMENT_DATASET` (for feature branches and staging)
 > - `SANITY_STUDIO_TITLE`
 > - `SANITY_STUDIO_PRESENTATION_URL`
 > - `SANITY_STUDIO_PRODUCTION_HOSTNAME`
@@ -110,6 +116,7 @@ The template includes a GitHub Actions workflow [`deploy-sanity.yml`](https://ra
 Set `SANITY_STUDIO_PRODUCTION_HOSTNAME` to whatever you want your deployed Sanity Studio hostname to be. Eg. for `SANITY_STUDIO_PRODUCTION_HOSTNAME=my-cool-project` you'll get a studio URL of `https://my-cool-project.sanity.studio` (and `<my-branch-name>-my-cool-project.sanity.studio` for PR previews builds done automatically via the `deploy-sanity.yml` github CI workflow when you open a PR.)
 
 Set `SANITY_STUDIO_PRESENTATION_URL` to your web app front-end URL (from the Vercel deployment). This URL is required for production deployments and should be:
+
 - Set in your GitHub repository secrets for CI/CD deployments
 - Set in your local environment if deploying manually with `npx sanity deploy`
 - Not needed for local development, where preview will automatically use http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The template includes a GitHub Actions workflow [`deploy-sanity.yml`](https://ra
 > - `SANITY_STUDIO_PRESENTATION_URL`
 > - `SANITY_STUDIO_PRODUCTION_HOSTNAME`
 
-Set `SANITY_STUDIO_PRODUCTION_HOSTNAME` to whatever you want your deployed Sanity Studio hostname to be. Eg. for `SANITY_STUDIO_PRODUCTION_HOSTNAME=my-cool-project` you'll get a studio URL of `https://my-cool-project.sanity.studio` (and `<my-branch-name>-my-cool-project.sanity.studio` for PR previews builds done automatically via the `deploy-sanity.yml` github CI workflow when you open a PR.)
+Set `SANITY_STUDIO_PRODUCTION_HOSTNAME` to whatever you want your deployed Sanity Studio hostname to be. Eg. for `SANITY_STUDIO_PRODUCTION_HOSTNAME=my-cool-project` you'll get a studio URL of `https://my-cool-project.sanity.studio` (and `<my-branch-name>-my-cool-project.sanity.studio` for PR previews builds done automatically via the `deploy-sanity.yml` github CI workflow when you open a PR. Branch names with slashes are automatically sanitized to use hyphens, e.g. `feature/new-component` becomes `feature-new-component-my-cool-project.sanity.studio`.)
 
 Set `SANITY_STUDIO_PRESENTATION_URL` to your web app front-end URL (from the Vercel deployment). This URL is required for production deployments and should be:
 

--- a/apps/studio/sanity.cli.ts
+++ b/apps/studio/sanity.cli.ts
@@ -15,7 +15,12 @@ function getStudioHost(): string | undefined {
   const projectId = process.env.SANITY_STUDIO_PROJECT_ID;
 
   if (productionHostName) {
-    if (host && host !== "main") return `${host}-${productionHostName}`;
+    if (host && host !== "main") {
+      // Sanitize branch name by replacing slashes with hyphens
+      // e.g. feature/new-component -> feature-new-component
+      const sanitizedHost = host.replace(/\//g, "-");
+      return `${sanitizedHost}-${productionHostName}`;
+    }
 
     return productionHostName;
   }

--- a/github/workflows/deploy-sanity.yml
+++ b/github/workflows/deploy-sanity.yml
@@ -20,11 +20,11 @@ jobs:
       NODE_OPTIONS: "--max_old_space_size=4096"
       PNPM_VERSION: 10.12.2
       SANITY_STUDIO_PROJECT_ID: ${{ secrets.SANITY_STUDIO_PROJECT_ID }}
-      SANITY_STUDIO_DATASET: ${{ secrets.SANITY_STUDIO_DATASET }}
+      SANITY_STUDIO_DATASET: ${{ github.ref_name == 'main' && secrets.SANITY_STUDIO_PRODUCTION_DATASET || secrets.SANITY_STUDIO_DEVELOPMENT_DATASET }}
       SANITY_STUDIO_TITLE: ${{ secrets.SANITY_STUDIO_TITLE }}
       SANITY_STUDIO_PRESENTATION_URL: ${{ secrets.SANITY_STUDIO_PRESENTATION_URL }}
       SANITY_STUDIO_PRODUCTION_HOSTNAME: ${{ secrets.SANITY_STUDIO_PRODUCTION_HOSTNAME }}
-      HOST_NAME: ${{ github.head_ref || github.ref_name }}  
+      HOST_NAME: ${{ github.head_ref || github.ref_name }}
 
     steps:
       - name: Checkout repository
@@ -42,11 +42,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts --prefer-offline
-        
+
       - name: Check if Dependabot
         id: check-dependabot
         run: |
@@ -64,7 +64,7 @@ jobs:
           pnpm run build
         env:
           CI: true
-        
+
       - name: Deploy Sanity Studio
         if: steps.check-dependabot.outputs.is_dependabot != 'true'
         working-directory: ./apps/studio


### PR DESCRIPTION
## Description

Implements branch-based dataset selection to prevent accidentally editing production data during development. The workflow now automatically uses different datasets based on the branch:

- **`main` branch**: Uses `SANITY_STUDIO_PRODUCTION_DATASET` for production deployments
- **All other branches**: Uses `SANITY_STUDIO_DEVELOPMENT_DATASET` for feature branches and staging

Also fixes the "Bad Request" errors for branch names with slashes (e.g., `feature/new-component` becomes `feature-new-component-my-project.sanity.studio`).

## Type of change

- [x] Feature
- [x] Fix
- [ ] Refactor
- [x] Documentation

## Testing

- Verified production deployments use correct dataset
- Confirmed feature branch deployments use development dataset  
- Tested hostname sanitization with branch names containing slashes
