### PR TITLE
fix: change logo to icon in Sanity Studio config

### DIFF
--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -21,7 +21,7 @@ const title = process.env.SANITY_STUDIO_TITLE;
 export default defineConfig({
   name: "default",
   title: title,
-  logo: Logo,
+  icon: Logo,
   projectId: projectId,
   dataset: dataset ?? "production",
   releases: {


### PR DESCRIPTION
## Description

- The logo was not displaying in the Sanity Studio because the configuration was using `logo` instead of `icon`.
- Changed `logo: Logo` to `icon: Logo` in the `defineConfig`
- This ensures the logo displays properly in Sanity Studio
   
## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation

## Screenshots (if applicable)

**Before:**

<img width="1600" height="900" alt="logo-before" src="https://github.com/user-attachments/assets/0e0bfca9-0d2d-4bfc-a2b4-8789cb5a3b3a" />

**After:**

<img width="1600" height="900" alt="logo-after" src="https://github.com/user-attachments/assets/22751709-8964-49f6-89ea-4cd2e6033316" />



