### PR TITLE
fix: remove duplicate unsplashImageAsset plugin

### DIFF
--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -48,7 +48,6 @@ export default defineConfig({
     media(),
     iconPicker(),
     assist(),
-    unsplashImageAsset(),
   ],
   document: {
     newDocumentOptions: (prev, { creationContext }) => {


### PR DESCRIPTION
## Description

- The `unsplashImageAsset` plugin was duplicated in the plugins array, causing it to appear twice in the image actions menu.
- Removed the duplicate `unsplashImageAsset()` entry from the plugins array

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation

## Screenshots (if applicable)

![duplicate-unsplash](https://github.com/user-attachments/assets/1d49674a-1d98-4d15-a3ba-274e50f70a3a)

