### PR TITLE
Refactor slug handling across document schemas

### DIFF
--- a/apps/studio/sanity.blueprint.ts
+++ b/apps/studio/sanity.blueprint.ts
@@ -1,4 +1,4 @@
-import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
+import { defineBlueprint, defineDocumentFunction } from "@sanity/blueprints";
 
 export default defineBlueprint({
   resources: [
@@ -9,12 +9,11 @@ export default defineBlueprint({
       memory: 2,
       timeout: 30,
       event: {
-        on: [
-          "publish"
-        ],
+        on: ["publish"],
         filter: "delta::changedAny(slug.current)",
-        projection: "{'beforeSlug': before().slug.current, 'slug': after().slug.current}"
-      }
-    })
+        projection:
+          "{'beforeSlug': before().slug.current, 'slug': after().slug.current}",
+      },
+    }),
   ],
-})
+});

--- a/apps/studio/schemaTypes/common.ts
+++ b/apps/studio/schemaTypes/common.ts
@@ -1,6 +1,11 @@
 import { defineField } from "sanity";
 
+import { PathnameFieldComponent } from "../components";
 import { GROUP } from "../utils/constant";
+import {
+  createSlugValidator,
+  getDocumentTypeConfig,
+} from "../utils/slug-validation";
 
 export const richTextField = defineField({
   name: "richText",
@@ -36,3 +41,33 @@ export const iconField = defineField({
   description:
     "Choose a small picture symbol to represent this item, like a home icon or shopping cart",
 });
+
+export const documentSlugField = (
+  documentType: string,
+  options: {
+    group?: string;
+    description?: string;
+    title?: string;
+  } = {},
+) => {
+  const {
+    group,
+    description = `The web address where people can find your ${documentType} (automatically created from title)`,
+    title = "URL",
+  } = options;
+
+  return defineField({
+    name: "slug",
+    type: "slug",
+    title,
+    description,
+    group,
+    components: {
+      field: PathnameFieldComponent,
+    },
+    validation: (Rule) => [
+      Rule.required().error("A URL slug is required"),
+      Rule.custom(createSlugValidator(getDocumentTypeConfig(documentType))),
+    ],
+  });
+};

--- a/apps/studio/schemaTypes/documents/blog-index.ts
+++ b/apps/studio/schemaTypes/documents/blog-index.ts
@@ -3,9 +3,7 @@ import { defineField, defineType } from "sanity";
 import { GROUP, GROUPS } from "../../utils/constant";
 import { ogFields } from "../../utils/og-fields";
 import { seoFields } from "../../utils/seo-fields";
-import { createSlug, isUnique } from "../../utils/slug";
-import { createSlugValidator } from "../../utils/slug-validation";
-import { pageBuilderField } from "../common";
+import { documentSlugField, pageBuilderField } from "../common";
 
 export const blogIndex = defineType({
   name: "blogIndex",
@@ -29,24 +27,8 @@ export const blogIndex = defineType({
         "A short summary of what visitors can find on your blog. This helps people understand what your blog is about.",
       group: GROUP.MAIN_CONTENT,
     }),
-    defineField({
-      name: "slug",
-      type: "slug",
-      description:
-        "The web address for your blog page (for example, '/blog' would create a page at yourdomain.com/blog)",
+    documentSlugField("blogIndex", {
       group: GROUP.MAIN_CONTENT,
-      options: {
-        source: "title",
-        slugify: createSlug,
-        isUnique: isUnique,
-      },
-      validation: (Rule) =>
-        Rule.required().custom(
-          createSlugValidator({
-            documentType: "Blog index",
-            requiredPrefix: "/blog",
-          }),
-        ),
     }),
     defineField({
       name: "displayFeaturedBlogs",

--- a/apps/studio/schemaTypes/documents/blog.ts
+++ b/apps/studio/schemaTypes/documents/blog.ts
@@ -5,12 +5,10 @@ import {
 import { FileTextIcon } from "lucide-react";
 import { defineArrayMember, defineField, defineType } from "sanity";
 
-import { PathnameFieldComponent } from "../../components/slug-field-component";
 import { GROUP, GROUPS } from "../../utils/constant";
 import { ogFields } from "../../utils/og-fields";
 import { seoFields } from "../../utils/seo-fields";
-import { createSlug, isUnique } from "../../utils/slug";
-import { createSlugValidator } from "../../utils/slug-validation";
+import { documentSlugField } from "../common";
 
 export const blog = defineType({
   name: "blog",
@@ -52,30 +50,8 @@ export const blog = defineType({
           ),
       ],
     }),
-    defineField({
-      name: "slug",
-      type: "slug",
-      title: "URL",
-      description:
-        "The web address where people can find your blog post (automatically created from title)",
+    documentSlugField("blog", {
       group: GROUP.MAIN_CONTENT,
-      components: {
-        field: PathnameFieldComponent,
-      },
-      options: {
-        source: "title",
-        slugify: createSlug,
-        isUnique,
-      },
-      validation: (Rule) => [
-        Rule.required().error("A URL slug is required"),
-        Rule.custom(
-          createSlugValidator({
-            documentType: "Blog post",
-            requiredPrefix: "/blog/",
-          }),
-        ),
-      ],
     }),
     defineField({
       name: "authors",

--- a/apps/studio/schemaTypes/documents/home-page.ts
+++ b/apps/studio/schemaTypes/documents/home-page.ts
@@ -4,9 +4,7 @@ import { defineField, defineType } from "sanity";
 import { GROUP, GROUPS } from "../../utils/constant";
 import { ogFields } from "../../utils/og-fields";
 import { seoFields } from "../../utils/seo-fields";
-import { createSlug } from "../../utils/slug";
-import { createSlugValidator } from "../../utils/slug-validation";
-import { pageBuilderField } from "../common";
+import { documentSlugField, pageBuilderField } from "../common";
 
 export const homePage = defineType({
   name: "homePage",
@@ -45,24 +43,8 @@ export const homePage = defineType({
           ),
       ],
     }),
-    defineField({
-      name: "slug",
-      type: "slug",
-      description:
-        "The web address for your home page. Usually this is just '/' for the main page of your website.",
+    documentSlugField("homePage", {
       group: GROUP.MAIN_CONTENT,
-      options: {
-        source: "title",
-        slugify: createSlug,
-      },
-      validation: (Rule) =>
-        Rule.required().custom(
-          createSlugValidator({
-            documentType: "Home page",
-            requiredPrefix: "/",
-            sanityDocumentType: "homePage",
-          }),
-        ),
     }),
     pageBuilderField,
     ...seoFields.filter(

--- a/apps/studio/schemaTypes/documents/page.ts
+++ b/apps/studio/schemaTypes/documents/page.ts
@@ -1,16 +1,10 @@
 import { DocumentIcon } from "@sanity/icons";
 import { defineField, defineType } from "sanity";
 
-import {
-  PathnameFieldComponent,
-  UrlSlugFieldComponent,
-} from "../../components";
 import { GROUP, GROUPS } from "../../utils/constant";
 import { ogFields } from "../../utils/og-fields";
 import { seoFields } from "../../utils/seo-fields";
-import { createSlug, isUnique } from "../../utils/slug";
-import { createSlugValidator } from "../../utils/slug-validation";
-import { pageBuilderField } from "../common";
+import { documentSlugField, pageBuilderField } from "../common";
 
 export const page = defineType({
   name: "page",
@@ -51,39 +45,8 @@ export const page = defineType({
           ),
       ],
     }),
-    defineField({
-      name: "slug",
-      type: "slug",
-      title: "URL",
-      description:
-        "The web address for this page (for example, '/about-us' would create a page at yourdomain.com/about-us)",
+    documentSlugField("page", {
       group: GROUP.MAIN_CONTENT,
-      components: {
-        field: PathnameFieldComponent,
-      },
-      options: {
-        source: "title",
-        slugify: createSlug,
-        isUnique,
-      },
-      validation: (Rule) =>
-        Rule.required()
-          // .error("A URL slug is required for the page")
-          .custom((slug) => {
-            // First run basic validation
-            const basicValidation = createSlugValidator({
-              documentType: "Page",
-            })(slug);
-
-            if (basicValidation !== true) return basicValidation;
-
-            // Then check that pages don't use blog prefixes
-            if (slug?.current?.startsWith("/blog")) {
-              return 'Pages cannot use "/blog" prefix - this is reserved for blog content';
-            }
-
-            return true;
-          }),
     }),
     defineField({
       name: "image",

--- a/apps/studio/schemaTypes/documents/redirect.ts
+++ b/apps/studio/schemaTypes/documents/redirect.ts
@@ -1,40 +1,42 @@
 // schemas/redirect.ts
-import {defineType, defineField} from 'sanity'
+import { defineField, defineType } from "sanity";
 
 export const redirect = defineType({
-  name: 'redirect',
-  title: 'Redirect',
-  type: 'document',
-  description: 'Redirect for next.config.js',
+  name: "redirect",
+  title: "Redirect",
+  type: "document",
+  description: "Redirect for next.config.js",
   fields: [
     defineField({
-      name: 'source',
-      type: 'slug',
-      validation: (rule) => rule.required().custom((value) => {
-        if (!value || !value.current) return "Can't be blank"
-        if (!value.current.startsWith('/')) {
-          return 'The path must start with a /'
-        }
-        return true
-      })
+      name: "source",
+      type: "slug",
+      validation: (rule) =>
+        rule.required().custom((value) => {
+          if (!value || !value.current) return "Can't be blank";
+          if (!value.current.startsWith("/")) {
+            return "The path must start with a /";
+          }
+          return true;
+        }),
     }),
     defineField({
-      name: 'destination',
-      type: 'slug',
-      validation: (rule) => rule.required().custom((value) => {
-        if (!value || !value.current) return "Can't be blank"
-        if (!value.current.startsWith('/')) {
-          return 'The path must start with a /'
-        }
-        return true
-      })
+      name: "destination",
+      type: "slug",
+      validation: (rule) =>
+        rule.required().custom((value) => {
+          if (!value || !value.current) return "Can't be blank";
+          if (!value.current.startsWith("/")) {
+            return "The path must start with a /";
+          }
+          return true;
+        }),
     }),
     defineField({
-      name: 'permanent',
-      type: 'boolean',
+      name: "permanent",
+      type: "boolean",
     }),
   ],
   initialValue: {
     permanent: true,
   },
-})
+});

--- a/apps/studio/utils/slug-validation.ts
+++ b/apps/studio/utils/slug-validation.ts
@@ -13,6 +13,7 @@ export interface SlugValidationOptions {
   requireSlash?: boolean;
   requiredPrefix?: string;
   sanityDocumentType?: string; // Auto-configure based on Sanity document type
+  segmentCount?: number;
 }
 
 /**
@@ -62,27 +63,38 @@ export const SLUG_WARNING_MESSAGES = {
 /**
  * Gets document-type specific configuration
  */
-function getDocumentTypeConfig(
+export function getDocumentTypeConfig(
   sanityDocumentType: string,
 ): SlugValidationOptions {
   switch (sanityDocumentType) {
+    case "author":
+      return {
+        documentType: "Author",
+        requiredPrefix: "/author/",
+        requireSlash: true,
+        segmentCount: 2,
+      };
     case "blog":
       return {
         documentType: "Blog post",
         requiredPrefix: "/blog/",
         requireSlash: true,
+        segmentCount: 2,
       };
     case "blogIndex":
       return {
         documentType: "Blog index",
         requiredPrefix: "/blog",
         requireSlash: true,
+        segmentCount: 1,
       };
     case "homePage":
       return {
         documentType: "Home page",
+        sanityDocumentType: "homePage",
         requiredPrefix: "/",
         requireSlash: true,
+        segmentCount: 0,
       };
     case "page":
       return {
@@ -183,6 +195,14 @@ export function validateSlug(
     //     );
     //   }
     // });
+
+    if (finalOptions.segmentCount !== undefined) {
+      if (segments.length !== finalOptions.segmentCount) {
+        allErrors.push(
+          `${finalOptions.documentType} URLs must have ${finalOptions.segmentCount} segments`,
+        );
+      }
+    }
 
     // Additional path-specific validations - critical errors
     if (finalOptions.requireSlash && !slug.startsWith("/")) {


### PR DESCRIPTION
- Introduced a reusable `documentSlugField` function to standardize slug field definitions in various document types.
- Updated `blog`, `homePage`, `page`, and `blogIndex` schemas to utilize the new slug field function, improving code consistency and maintainability.
- Enhanced slug validation options in `slug-validation.ts` to support segment count validation for better URL structure enforcement.

## Description

<!-- Brief description of changes -->

## Type of change

- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Documentation

## Screenshots (if applicable)

<!-- Screenshots of visual changes -->

## Testing

<!-- How were these changes tested? -->

## Related issues

<!-- Reference any related issues (e.g., Fixes #123) -->
