### PR TITLE
correct-sanity-version 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A modern, full-stack monorepo template built with Next.js App Router, Sanity CMS
 
 ### Content Management (Studio)
 
-- Sanity Studio v3
+- Sanity Studio v4
 - Custom document types (Blog, FAQ, Pages)
 - Visual editing integration
 - Structured content with schemas
@@ -110,9 +110,10 @@ The template includes a GitHub Actions workflow [`deploy-sanity.yml`](https://ra
 Set `SANITY_STUDIO_PRODUCTION_HOSTNAME` to whatever you want your deployed Sanity Studio hostname to be. Eg. for `SANITY_STUDIO_PRODUCTION_HOSTNAME=my-cool-project` you'll get a studio URL of `https://my-cool-project.sanity.studio` (and `<my-branch-name>-my-cool-project.sanity.studio` for PR previews builds done automatically via the `deploy-sanity.yml` github CI workflow when you open a PR.)
 
 Set `SANITY_STUDIO_PRESENTATION_URL` to your web app front-end URL (from the Vercel deployment). This URL is required for production deployments and should be:
+
 - Set in your GitHub repository secrets for CI/CD deployments
 - Set in your local environment if deploying manually with `npx sanity deploy`
-- Not needed for local development, where preview will automatically use http://localhost:3000
+- Not needed for local development, where preview will automatically use `http://localhost:3000`
 
 You can then manually deploy from your Studio directory (`/studio`) using:
 


### PR DESCRIPTION
## Description

This corrects the root README.md file to Sanity v4 instead of v3. The URL issue was prompted when running markdown lint.

## Type of change

- [ ] Feature
- [X] Fix
- [ ] Refactor
- [ ] Documentation
