### PR TITLE
add error handling and resolve document creation issue

### DIFF
--- a/apps/studio/sanity.cli.ts
+++ b/apps/studio/sanity.cli.ts
@@ -3,6 +3,9 @@ import { defineCliConfig } from "sanity/cli";
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID;
 const dataset = process.env.SANITY_STUDIO_DATASET;
 
+if (!projectId || projectId === 'project_id') throw new Error('Missing required environment variable: SANITY_STUDIO_PROJECT_ID')
+if (!dataset || dataset === 'dataset') throw new Error('Missing required environment variable: SANITY_STUDIO_DATASET')
+
 /**
  * Returns the correct studio host based on environment variables.
  * - If HOST_NAME is set and not "main", returns `${HOST_NAME}-${PRODUCTION_HOSTNAME}`

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -15,7 +15,7 @@ import { structure } from "./structure";
 import { getPresentationUrl } from "./utils/helper";
 
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID ?? "";
-const dataset = process.env.SANITY_STUDIO_DATASET;
+const dataset = process.env.SANITY_STUDIO_DATASET ?? "production";
 const title = process.env.SANITY_STUDIO_TITLE;
 
 export default defineConfig({
@@ -23,7 +23,7 @@ export default defineConfig({
   title,
   icon: Logo,
   projectId,
-  dataset: dataset ?? "production",
+  dataset,
   releases: {
     enabled: true,
   },
@@ -53,7 +53,18 @@ export default defineConfig({
     newDocumentOptions: (prev, { creationContext }) => {
       const { type } = creationContext;
       if (type === "global") {
-        return [];
+        return prev.filter(
+          (template) =>
+            ![
+              'homePage',
+              'navbar',
+              'footer',
+              'settings',
+              'blogIndex',
+              'assist.instruction.context',
+              'media.tag',
+            ].includes(template?.templateId),
+        )
       }
       return prev;
     },


### PR DESCRIPTION
## Description

This corrects the issue of not being able to create a new document from the header. This also improves and adds error handling for new users that may have missing `projectId` and `dataset` set in their env file. 

## Type of change

- [ ] Feature
- [X] Fix
- [X] Refactor
- [ ] Documentation

## Screenshots (if applicable)

<img width="328" height="273" alt="Screenshot 2025-12-01 at 10 04 35 AM" src="https://github.com/user-attachments/assets/21eeae18-b6d4-4d40-82ba-fd24e6cd60bf" />

## Testing

ran locally
