### PR TITLE
feat: integrate lucide icon picker and update related components

### DIFF
--- a/apps/studio/components/icon-preview.tsx
+++ b/apps/studio/components/icon-preview.tsx
@@ -1,0 +1,12 @@
+import { TriangleAlert } from "lucide-react";
+import { DynamicIcon, type dynamicIconImports } from "lucide-react/dynamic";
+
+export const lucideIconPreview = (icon: keyof typeof dynamicIconImports) => {
+  return (
+    <DynamicIcon
+      name={icon}
+      fallback={() => <TriangleAlert size={24} />}
+      size={24}
+    />
+  );
+};

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -37,6 +37,7 @@
     "sanity": "^4.19.0",
     "sanity-plugin-asset-source-unsplash": "^4.0.1",
     "sanity-plugin-icon-picker": "^4.0.0",
+    "sanity-plugin-lucide-icon-picker": "^1.0.3",
     "sanity-plugin-media": "^4.0.0",
     "slugify": "^1.6.6",
     "styled-components": "^6.1.19"

--- a/apps/studio/sanity.cli.ts
+++ b/apps/studio/sanity.cli.ts
@@ -3,8 +3,14 @@ import { defineCliConfig } from "sanity/cli";
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID;
 const dataset = process.env.SANITY_STUDIO_DATASET;
 
-if (!projectId || projectId === 'project_id') throw new Error('Missing required environment variable: SANITY_STUDIO_PROJECT_ID')
-if (!dataset || dataset === 'dataset') throw new Error('Missing required environment variable: SANITY_STUDIO_DATASET')
+if (!projectId || projectId === "project_id")
+  throw new Error(
+    "Missing required environment variable: SANITY_STUDIO_PROJECT_ID"
+  );
+if (!dataset || dataset === "dataset")
+  throw new Error(
+    "Missing required environment variable: SANITY_STUDIO_DATASET"
+  );
 
 /**
  * Returns the correct studio host based on environment variables.

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -5,6 +5,7 @@ import { presentationTool } from "sanity/presentation";
 import { structureTool } from "sanity/structure";
 import { unsplashImageAsset } from "sanity-plugin-asset-source-unsplash";
 import { iconPicker } from "sanity-plugin-icon-picker";
+import { lucideIconPicker } from "sanity-plugin-lucide-icon-picker";
 import { media } from "sanity-plugin-media";
 
 import { Logo } from "./components/logo";
@@ -44,9 +45,9 @@ export default defineConfig({
     }),
     presentationUrl(),
     visionTool(),
+    lucideIconPicker(),
     unsplashImageAsset(),
     media(),
-    iconPicker(),
     assist(),
   ],
   document: {
@@ -56,15 +57,15 @@ export default defineConfig({
         return prev.filter(
           (template) =>
             ![
-              'homePage',
-              'navbar',
-              'footer',
-              'settings',
-              'blogIndex',
-              'assist.instruction.context',
-              'media.tag',
-            ].includes(template?.templateId),
-        )
+              "homePage",
+              "navbar",
+              "footer",
+              "settings",
+              "blogIndex",
+              "assist.instruction.context",
+              "media.tag",
+            ].includes(template?.templateId)
+        );
       }
       return prev;
     },

--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -1056,7 +1056,7 @@
                   "type": "objectAttribute",
                   "value": {
                     "type": "inline",
-                    "name": "iconPicker"
+                    "name": "lucide-icon"
                   },
                   "optional": true
                 },
@@ -2551,7 +2551,7 @@
                             "type": "objectAttribute",
                             "value": {
                               "type": "inline",
-                              "name": "iconPicker"
+                              "name": "lucide-icon"
                             },
                             "optional": true
                           },
@@ -2688,40 +2688,10 @@
     }
   },
   {
-    "name": "iconPicker",
+    "name": "lucide-icon",
     "type": "type",
     "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "iconPicker"
-          }
-        },
-        "provider": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "name": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "svg": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
+      "type": "string"
     }
   },
   {

--- a/apps/studio/schemaTypes/blocks/feature-cards-icon.ts
+++ b/apps/studio/schemaTypes/blocks/feature-cards-icon.ts
@@ -1,7 +1,6 @@
 import { LayoutGrid } from "lucide-react";
 import { defineField, defineType } from "sanity";
-import { preview } from "sanity-plugin-icon-picker";
-
+import { lucideIconPreview } from "../../components/icon-preview";
 import { iconField } from "../common";
 import { customRichText } from "../definitions/rich-text";
 
@@ -24,7 +23,7 @@ const featureCardIcon = defineField({
     },
     prepare: ({ title, icon }) => ({
       title: `${title ?? "Untitled"}`,
-      media: icon ? preview(icon) : null,
+      media: lucideIconPreview(icon),
     }),
   },
 });

--- a/apps/studio/schemaTypes/common.ts
+++ b/apps/studio/schemaTypes/common.ts
@@ -39,10 +39,11 @@ export const iconField = defineField({
   name: "icon",
   title: "Icon",
   options: {
-    storeSvg: true,
-    providers: ["fi"],
+    // storeSvg: true,
+    // providers: ["fi"],
   },
-  type: "iconPicker",
+  // type: "iconPicker",
+  type: "lucide-icon",
   description:
     "Choose a small picture symbol to represent this item, like a home icon or shopping cart",
 });

--- a/apps/studio/schemaTypes/documents/navbar.ts
+++ b/apps/studio/schemaTypes/documents/navbar.ts
@@ -1,6 +1,6 @@
 import { LayoutPanelLeft, Link, PanelTop } from "lucide-react";
 import { defineField, defineType } from "sanity";
-
+import { lucideIconPreview } from "../../components/icon-preview";
 import { buttonsField, iconField } from "../common";
 
 const navbarLink = defineField({
@@ -80,8 +80,9 @@ const navbarColumnLink = defineField({
       urlType: "url.type",
       internalUrl: "url.internal.slug.current",
       openInNewTab: "url.openInNewTab",
+      icon: "icon",
     },
-    prepare({ title, externalUrl, urlType, internalUrl, openInNewTab }) {
+    prepare({ title, icon, externalUrl, urlType, internalUrl, openInNewTab }) {
       const url = urlType === "external" ? externalUrl : internalUrl;
       const newTabIndicator = openInNewTab ? " ↗" : "";
       const truncatedUrl =
@@ -90,7 +91,7 @@ const navbarColumnLink = defineField({
       return {
         title: title || "Untitled Link",
         subtitle: `${urlType === "external" ? "External" : "Internal"} • ${truncatedUrl}${newTabIndicator}`,
-        media: Link,
+        media: lucideIconPreview(icon),
       };
     },
   },

--- a/apps/web/src/components/blog-search-results.tsx
+++ b/apps/web/src/components/blog-search-results.tsx
@@ -64,7 +64,8 @@ function ErrorState({ query }: { query: string }) {
           Search failed
         </h3>
         <p className="mb-4 text-muted-foreground">
-          We encountered an error while searching for "{query}". Please try again.
+          We encountered an error while searching for "{query}". Please try
+          again.
         </p>
         <div className="text-muted-foreground text-sm">
           <p>If the problem persists:</p>

--- a/apps/web/src/components/elements/sanity-icon.tsx
+++ b/apps/web/src/components/elements/sanity-icon.tsx
@@ -1,41 +1,43 @@
 import { cn } from "@workspace/ui/lib/utils";
+import { TriangleAlert } from "lucide-react";
+import { DynamicIcon, type IconName } from "lucide-react/dynamic";
 import type { ComponentProps } from "react";
 import { memo } from "react";
 
-interface IconProps extends Omit<ComponentProps<"span">, "src"> {
-  icon?:
-    | {
-        svg?: string | null;
-        name?: string | null;
-      }
-    | string
-    | null;
+interface IconProps extends Omit<ComponentProps<"svg">, "src"> {
+  icon?: string | null;
   alt?: string; // Add alt text prop for accessibility
 }
 
 export const SanityIcon = memo(function SanityIconUnmemorized({
   icon,
   className,
-  alt: altText = "sanity-icon",
   ...props
 }: IconProps) {
-  const alt = typeof icon === "object" && icon?.name ? icon?.name : altText;
-  const svg = typeof icon === "object" ? icon?.svg : icon;
-
-  if (!svg) {
+  if (!icon) {
     return null;
   }
 
   return (
-    <span
+    <DynamicIcon
       {...props}
-      className={cn(
-        "sanity-icon flex size-12 items-center justify-center",
-        className
-      )}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: safe SVG from CMS
-      dangerouslySetInnerHTML={{ __html: svg }}
-      title={alt}
+      name={icon as IconName}
+      className={cn("size-12", className)}
+      fallback={() => <TriangleAlert size={24} />}
+      size={24}
     />
   );
+
+  // return (
+  //   <span
+  //     {...props}
+  //     className={cn(
+  //       "sanity-icon flex size-12 items-center justify-center",
+  //       className
+  //     )}
+  //     // biome-ignore lint/security/noDangerouslySetInnerHtml: safe SVG from CMS
+  //     dangerouslySetInnerHTML={{ __html: svg }}
+  //     title={alt}
+  //   />
+  // );
 });

--- a/apps/web/src/components/sections/cta.tsx
+++ b/apps/web/src/components/sections/cta.tsx
@@ -7,12 +7,7 @@ import { SanityButtons } from "../elements/sanity-buttons";
 
 export type CTABlockProps = PagebuilderType<"cta">;
 
-export function CTABlock({
-  richText,
-  title,
-  eyebrow,
-  buttons,
-}: CTABlockProps) {
+export function CTABlock({ richText, title, eyebrow, buttons }: CTABlockProps) {
   return (
     <section className="my-6 md:my-16" id="features">
       <div className="container mx-auto px-4 md:px-8">

--- a/apps/web/src/hooks/use-blog-search.ts
+++ b/apps/web/src/hooks/use-blog-search.ts
@@ -11,8 +11,6 @@ async function searchBlog(query: string, signal: AbortSignal) {
     return [];
   }
 
-
-
   const response = await fetch(
     `/api/blog/search?q=${encodeURIComponent(query)}`,
     { signal }

--- a/apps/web/src/lib/sanity/sanity.types.ts
+++ b/apps/web/src/lib/sanity/sanity.types.ts
@@ -145,7 +145,7 @@ export type FeatureCardsIcon = {
     _key: string;
   }>;
   cards?: Array<{
-    icon?: IconPicker;
+    icon?: LucideIcon;
     title?: string;
     richText?: Array<{
       children?: Array<{
@@ -360,7 +360,7 @@ export type Navbar = {
     | {
         title?: string;
         links: Array<{
-          icon?: IconPicker;
+          icon?: LucideIcon;
           name?: string;
           description?: string;
           url?: CustomUrl;
@@ -384,12 +384,7 @@ export type Navbar = {
   >;
 };
 
-export type IconPicker = {
-  _type: "iconPicker";
-  provider?: string;
-  name?: string;
-  svg?: string;
-};
+export type LucideIcon = string;
 
 export type Footer = {
   _id: string;
@@ -916,7 +911,7 @@ export type AllSanitySchemaTypes =
   | Redirect
   | Slug
   | Navbar
-  | IconPicker
+  | LucideIcon
   | Footer
   | Settings
   | SanityImageCrop
@@ -1099,7 +1094,7 @@ export type QueryHomePageDataResult = {
           _key: string;
         }> | null;
         cards: Array<{
-          icon?: IconPicker;
+          icon?: LucideIcon;
           title?: string;
           richText: Array<{
             children?: Array<{
@@ -1475,7 +1470,7 @@ export type QuerySlugPageDataResult = {
           _key: string;
         }> | null;
         cards: Array<{
-          icon?: IconPicker;
+          icon?: LucideIcon;
           title?: string;
           richText: Array<{
             children?: Array<{
@@ -1844,7 +1839,7 @@ export type QueryBlogIndexPageDataResult = {
           _key: string;
         }> | null;
         cards: Array<{
-          icon?: IconPicker;
+          icon?: LucideIcon;
           title?: string;
           richText: Array<{
             children?: Array<{
@@ -2418,7 +2413,7 @@ export type QueryNavbarDataResult = {
         links: Array<{
           _key: string;
           name: string | null;
-          icon: IconPicker | null;
+          icon: LucideIcon | null;
           description: string | null;
           openInNewTab: boolean | null;
           href: string | null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       sanity-plugin-icon-picker:
         specifier: ^4.0.0
         version: 4.0.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10)(debug@4.4.3))(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3)))(@types/node@24.0.3)(@types/react@19.1.10)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))
+      sanity-plugin-lucide-icon-picker:
+        specifier: ^1.0.3
+        version: 1.0.3(@sanity/icons@3.7.4(react@19.1.1))(@sanity/ui@3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)))(react@19.1.1)(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10)(debug@4.4.3))(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3)))(@types/node@24.0.3)(@types/react@19.1.10)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))
       sanity-plugin-media:
         specifier: ^4.0.0
         version: 4.0.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10)(debug@4.4.3))(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3)))(@types/node@24.0.3)(@types/react@19.1.10)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
@@ -4913,6 +4916,11 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lucide-react@0.532.0:
+    resolution: {integrity: sha512-HwmXOIZwuZ21wryFq0ZrwkjAMxI77+jLxLdNzWCiUa/Kf5ozkTFCWT6C1/yapP68uKgj8wlxxqnNCH1xo9NEpg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lucide-react@0.539.0:
     resolution: {integrity: sha512-VVISr+VF2krO91FeuCrm1rSOLACQUYVy7NQkzrOty52Y8TlTPcXcMdQFj9bYzBgXbWCiywlwSZ3Z8u6a+6bMlg==}
     peerDependencies:
@@ -5952,6 +5960,15 @@ packages:
       react: ^18.3 || ^19
       react-dom: ^18.3 || ^19
       react-is: ^18.3 || ^19
+      sanity: ^3
+
+  sanity-plugin-lucide-icon-picker@1.0.3:
+    resolution: {integrity: sha512-3KS2pE4pCJ/LbUVw0iA2cCg/0KjMSnbEei9VJW3blAtwQRgionRgpytDcCJ1pXMho9gZc6Aqa91Jpjn3TllccA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@sanity/icons': ^3.7.0
+      '@sanity/ui': ^2.0.0
+      react: ^18 || ^19
       sanity: ^3
 
   sanity-plugin-media@4.0.0:
@@ -9619,7 +9636,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@sanity/insert-menu@2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))':
+  '@sanity/insert-menu@2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.1.1)
       '@sanity/types': 4.19.0(@types/react@19.1.10)(debug@4.4.3)
@@ -9745,10 +9762,10 @@ snapshots:
       - react-is
       - rxjs
 
-  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))':
+  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
@@ -10021,13 +10038,13 @@ snapshots:
   '@sanity/visual-editing-csm@2.0.26(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))(typescript@5.9.2)':
     dependencies:
       '@sanity/client': 7.13.1(debug@4.4.3)
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))
       valibot: 1.1.0(typescript@5.9.2)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))':
     dependencies:
       '@sanity/client': 7.13.1(debug@4.4.3)
     optionalDependencies:
@@ -10037,9 +10054,9 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.1.1)
-      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.24.0)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.1.1))(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10))(@sanity/types@4.19.0(@types/react@19.1.10)))(@types/node@20.19.11)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(babel-plugin-react-compiler@19.1.0-rc.2)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))
       '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))(typescript@5.9.2)
@@ -12217,6 +12234,10 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  lucide-react@0.532.0(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+
   lucide-react@0.539.0(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -12414,7 +12435,7 @@ snapshots:
       '@portabletext/react': 5.0.0(react@19.1.1)
       '@sanity/client': 7.13.1(debug@4.4.3)
       '@sanity/comlink': 4.0.1
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.1.1))(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10))(@sanity/types@4.19.0(@types/react@19.1.10)))(@types/node@20.19.11)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(babel-plugin-react-compiler@19.1.0-rc.2)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))
       '@sanity/visual-editing': 4.0.2(@emotion/is-prop-valid@1.2.2)(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))(next@16.0.5(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10))(@sanity/types@4.19.0(@types/react@19.1.10)))(@types/node@20.19.11)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(babel-plugin-react-compiler@19.1.0-rc.2)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(typescript@5.9.2)
       dequal: 2.0.3
@@ -13354,6 +13375,14 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
+  sanity-plugin-lucide-icon-picker@1.0.3(@sanity/icons@3.7.4(react@19.1.1))(@sanity/ui@3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)))(react@19.1.1)(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10)(debug@4.4.3))(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3)))(@types/node@24.0.3)(@types/react@19.1.10)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1)):
+    dependencies:
+      '@sanity/icons': 3.7.4(react@19.1.1)
+      '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.2.2)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      lucide-react: 0.532.0(react@19.1.1)
+      react: 19.1.1
+      sanity: 4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10)(debug@4.4.3))(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3)))(@types/node@24.0.3)(@types/react@19.1.10)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1)
+
   sanity-plugin-media@4.0.0(@emotion/is-prop-valid@1.2.2)(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10)(debug@4.4.3))(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3)))(@types/node@24.0.3)(@types/react@19.1.10)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
     dependencies:
       '@hookform/resolvers': 3.10.0(react-hook-form@7.54.2(react@19.1.1))
@@ -13441,13 +13470,13 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 1.2.0
       '@sanity/import': 3.38.3(@types/react@19.1.10)
-      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       '@sanity/logos': 2.2.2(react@19.1.1)
       '@sanity/media-library-types': 1.0.1
       '@sanity/message-protocol': 0.17.6
       '@sanity/migrate': 4.19.0(@types/react@19.1.10)
       '@sanity/mutator': 4.19.0(@types/react@19.1.10)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.1.1))(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10)(debug@4.4.3))(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3)))(@types/node@24.0.3)(@types/react@19.1.10)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))
       '@sanity/schema': 4.19.0(@types/react@19.1.10)(debug@4.4.3)
       '@sanity/sdk': 2.1.2(@types/react@19.1.10)(debug@4.4.3)(immer@11.0.1)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1))
@@ -13615,13 +13644,13 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 1.2.0
       '@sanity/import': 3.38.3(@types/react@19.1.10)
-      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.2.2)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))(react-dom@19.1.1(react@19.1.1))(react-is@19.1.1)(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       '@sanity/logos': 2.2.2(react@19.1.1)
       '@sanity/media-library-types': 1.0.1
       '@sanity/message-protocol': 0.17.6
       '@sanity/migrate': 4.19.0(@types/react@19.1.10)
       '@sanity/mutator': 4.19.0(@types/react@19.1.10)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10))
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@4.19.0(@types/react@19.1.10)(debug@4.4.3))
       '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.1.1))(sanity@4.19.0(@emotion/is-prop-valid@1.2.2)(@portabletext/sanity-bridge@1.2.6(@sanity/schema@4.19.0(@types/react@19.1.10))(@sanity/types@4.19.0(@types/react@19.1.10)))(@types/node@20.19.11)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(babel-plugin-react-compiler@19.1.0-rc.2)(immer@11.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(styled-components@6.1.19(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(terser@5.37.0)(typescript@5.9.2)(yaml@2.6.1))
       '@sanity/schema': 4.19.0(@types/react@19.1.10)(debug@4.4.3)
       '@sanity/sdk': 2.1.2(@types/react@19.1.10)(debug@4.4.3)(immer@11.0.1)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1))


### PR DESCRIPTION
- Added `sanity-plugin-lucide-icon-picker` to the project for enhanced icon selection.
- Updated schema and components to utilize the new lucide icon picker, replacing the previous icon picker.
- Refactored icon handling in various components to support dynamic icons from lucide-react.
- Improved error handling and code readability across several files.
- Cleaned up unnecessary code and comments for better maintainability.

## Description

<!-- Brief description of changes -->

## Type of change

- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Documentation

## Screenshots (if applicable)

<!-- Screenshots of visual changes -->

## Testing

<!-- How were these changes tested? -->

## Related issues

<!-- Reference any related issues (e.g., Fixes #123) -->
