### PR TITLE
Rob 1857 turbo start sanity build markdown routes in web app

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -25,6 +25,14 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async rewrites() {
+    return [
+      { source: "/.md", destination: "/api/md" },
+      { source: "/llms.txt", destination: "/api/llms-txt" },
+      { source: "/sitemap.md", destination: "/api/sitemap-md" },
+      { source: "/:path+.md", destination: "/api/md/:path+" },
+    ];
+  },
   async redirects() {
     const redirects = await client.fetch(queryRedirects);
     return redirects.map((redirect) => ({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@portabletext/markdown": "^1.1.2",
     "@sanity/asset-utils": "^2.3.0",
     "@sanity/client": "catalog:",
     "@sanity/image-url": "^2.0.3",

--- a/apps/web/src/app/api/llms-txt/route.ts
+++ b/apps/web/src/app/api/llms-txt/route.ts
@@ -13,7 +13,7 @@ function truncate(text: string): string {
 }
 
 function escapeMarkdownLink(text: string): string {
-  return text.replace(/[[\]()]/g, "\\$&");
+  return text.replace(/\\/g, "\\\\").replace(/[[\]()]/g, "\\$&");
 }
 
 export async function GET() {

--- a/apps/web/src/app/api/llms-txt/route.ts
+++ b/apps/web/src/app/api/llms-txt/route.ts
@@ -1,0 +1,98 @@
+import { client } from "@workspace/sanity/client";
+import { groq } from "next-sanity";
+
+const SITE_URL = process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
+  : "http://localhost:3000";
+
+const MAX_LENGTH = 80;
+
+function truncate(text: string): string {
+  if (text.length <= MAX_LENGTH) return text;
+  return `${text.substring(0, MAX_LENGTH - 3).trim()}...`;
+}
+
+function escapeMarkdownLink(text: string): string {
+  return text.replace(/[[\]()]/g, "\\$&");
+}
+
+export async function GET() {
+  const lines: string[] = [];
+
+  lines.push("# Turbo Start Sanity");
+  lines.push("");
+  lines.push("> A modern web application built with Next.js and Sanity CMS.");
+  lines.push("");
+  lines.push("## About");
+  lines.push("");
+  lines.push(`- Website: ${SITE_URL}`);
+  lines.push(`- Contact: ${SITE_URL}/contact`);
+  lines.push(`- Sitemap: ${SITE_URL}/sitemap.md`);
+  lines.push("");
+
+  try {
+    const [blogs, pages] = await Promise.all([
+      client.fetch<{ title: string; slug: string; description?: string }[]>(
+        groq`*[_type == "blog"] | order(publishedAt desc) [0...20] { title, "slug": slug.current, description }`,
+      ),
+      client.fetch<{ title: string; slug: string }[]>(
+        groq`*[_type == "page" && defined(slug.current)] | order(title asc) { title, "slug": slug.current }`,
+      ),
+    ]);
+
+    if (pages.length > 0) {
+      lines.push("## Pages");
+      lines.push("");
+      for (const item of pages) {
+        if (!item.slug) continue;
+        const url = `${SITE_URL}${item.slug}`;
+        const mdUrl = `${url}.md`;
+        lines.push(
+          `- [${escapeMarkdownLink(item.title)}](${url}) - [markdown](${mdUrl})`,
+        );
+      }
+      lines.push("");
+    }
+
+    if (blogs.length > 0) {
+      lines.push("## Blog Posts (Recent)");
+      lines.push("");
+      for (const item of blogs) {
+        if (!item.slug) continue;
+        const url = `${SITE_URL}${item.slug}`;
+        const mdUrl = `${url}.md`;
+        const desc = item.description
+          ? ` - ${truncate(item.description)}`
+          : "";
+        lines.push(
+          `- [${escapeMarkdownLink(item.title)}](${url}) - [markdown](${mdUrl})${desc}`,
+        );
+      }
+      lines.push("");
+    }
+  } catch (error) {
+    console.error("[llms-txt] Error fetching content:", error);
+  }
+
+  lines.push("## Technical Details");
+  lines.push("");
+  lines.push("- Built with: Next.js, React, Sanity CMS, TypeScript");
+  lines.push("- Markdown versions available at any URL + .md suffix");
+  lines.push(`- Content sitemap: ${SITE_URL}/sitemap.md`);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push(
+    "*This file follows the llms.txt standard for LLM agent discovery*",
+  );
+  lines.push(`*Last built: ${new Date().toISOString().split("T")[0]}*`);
+  lines.push("");
+
+  return new Response(lines.join("\n"), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/apps/web/src/app/api/md/[...path]/route.ts
+++ b/apps/web/src/app/api/md/[...path]/route.ts
@@ -1,0 +1,117 @@
+import { client } from "@workspace/sanity/client";
+import {
+  queryBlogIndexPageData,
+  queryBlogSlugPageData,
+  queryHomePageData,
+  querySlugPageData,
+} from "@workspace/sanity/query";
+import { groq } from "next-sanity";
+
+import { formatDocumentAsMarkdown } from "@/lib/markdown/formatter";
+
+/** Fetch all blog posts for the blog index markdown page. */
+const allBlogsQuery = groq`
+  *[_type == "blog" && defined(slug.current)] | order(publishedAt desc) {
+    title,
+    description,
+    "slug": slug.current,
+    publishedAt
+  }
+`;
+
+/** GROQ query that resolves a slug.current to its _type. */
+const detectTypeQuery = groq`
+  *[defined(slug.current) && slug.current == $slug][0]._type
+`;
+
+/** Map from Sanity _type to the query that fetches the full document. */
+const TYPE_QUERY_MAP: Record<string, string> = {
+  page: querySlugPageData,
+  blog: queryBlogSlugPageData,
+};
+
+/** Singleton types that use {} params (no slug needed). */
+const SINGLETON_TYPES: Record<string, string> = {
+  homePage: queryHomePageData,
+  blogIndex: queryBlogIndexPageData,
+};
+
+/** Known URL paths that map to singleton types (fallback when slug detection fails). */
+const PATH_TO_SINGLETON: Record<string, string> = {
+  "/blog": "blogIndex",
+};
+
+/**
+ * API route that renders any Sanity page as Markdown.
+ * Resolves the slug to a _type, selects the appropriate query,
+ * fetches the document, and formats it with formatDocumentAsMarkdown.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await params;
+  const slug = `/${path.join("/")}`;
+
+  try {
+    let documentType: string | null = await client.fetch(detectTypeQuery, {
+      slug,
+    });
+
+    // Fallback: check known URL-to-singleton mappings
+    if (!documentType && slug in PATH_TO_SINGLETON) {
+      documentType = PATH_TO_SINGLETON[slug]!;
+    }
+
+    if (!documentType) {
+      return new Response("Page not found", {
+        status: 404,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const isSingleton = documentType in SINGLETON_TYPES;
+    const query =
+      TYPE_QUERY_MAP[documentType] ?? SINGLETON_TYPES[documentType];
+
+    if (!query) {
+      return new Response("Page not found", {
+        status: 404,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const rawData = await client.fetch(query, isSingleton ? {} : { slug });
+    const data = Array.isArray(rawData) ? rawData[0] : rawData;
+
+    if (!data) {
+      return new Response("Page not found", {
+        status: 404,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    // For blogIndex, attach the actual blog posts to the data
+    if (documentType === "blogIndex") {
+      const blogs = await client.fetch(allBlogsQuery);
+      data.blogs = blogs;
+    }
+
+    const markdown = formatDocumentAsMarkdown({ type: documentType, data });
+
+    return new Response(markdown, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+        "X-Content-Type": documentType,
+      },
+    });
+  } catch (error) {
+    console.error("[api/md] Error:", error);
+    return new Response("Failed to render page as markdown", {
+      status: 500,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+}

--- a/apps/web/src/app/api/md/[...path]/route.ts
+++ b/apps/web/src/app/api/md/[...path]/route.ts
@@ -60,7 +60,7 @@ export async function GET(
 
     // Fallback: check known URL-to-singleton mappings
     if (!documentType && slug in PATH_TO_SINGLETON) {
-      documentType = PATH_TO_SINGLETON[slug]!;
+      documentType = PATH_TO_SINGLETON[slug] ?? null;
     }
 
     if (!documentType) {
@@ -93,8 +93,12 @@ export async function GET(
 
     // For blogIndex, attach the actual blog posts to the data
     if (documentType === "blogIndex") {
-      const blogs = await client.fetch(allBlogsQuery);
-      data.blogs = blogs;
+      try {
+        data.blogs = await client.fetch(allBlogsQuery);
+      } catch (blogError) {
+        console.error("[api/md] Failed to fetch blog posts:", blogError);
+        data.blogs = [];
+      }
     }
 
     const markdown = formatDocumentAsMarkdown({ type: documentType, data });

--- a/apps/web/src/app/api/md/route.ts
+++ b/apps/web/src/app/api/md/route.ts
@@ -1,0 +1,42 @@
+import { client } from "@workspace/sanity/client";
+import { queryHomePageData } from "@workspace/sanity/query";
+
+import { formatDocumentAsMarkdown } from "@/lib/markdown/formatter";
+
+/**
+ * Homepage markdown handler.
+ * /.md rewrites to /api/md (this file).
+ * Fetches the homePage singleton and formats it as markdown.
+ */
+export async function GET() {
+  try {
+    const data = await client.fetch(queryHomePageData);
+
+    if (!data) {
+      return new Response("Homepage not found", {
+        status: 404,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const markdown = formatDocumentAsMarkdown({
+      type: "homePage",
+      data,
+    });
+
+    return new Response(markdown, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
+        "X-Content-Type": "homePage",
+      },
+    });
+  } catch (error) {
+    console.error("[api/md] Homepage error:", error);
+    return new Response("Failed to render homepage as markdown", {
+      status: 500,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+}

--- a/apps/web/src/app/api/sitemap-md/route.ts
+++ b/apps/web/src/app/api/sitemap-md/route.ts
@@ -1,0 +1,69 @@
+import { client } from "@workspace/sanity/client";
+import { groq } from "next-sanity";
+
+const SITE_URL = process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
+  : "http://localhost:3000";
+
+interface SlugDoc {
+  title: string;
+  slug: string;
+}
+
+export async function GET() {
+  const lines: string[] = [];
+
+  lines.push("# Content Sitemap");
+  lines.push("");
+  lines.push(
+    "All pages are available in markdown format by appending `.md` to the URL.",
+  );
+  lines.push("");
+
+  try {
+    const CONTENT_TYPES = [
+      { type: "page", label: "Pages" },
+      { type: "blog", label: "Blog Posts" },
+    ];
+
+    const results = await Promise.all(
+      CONTENT_TYPES.map(({ type }) =>
+        client.fetch<SlugDoc[]>(
+          groq`*[_type == $type && defined(slug.current)] | order(title asc) {
+            title,
+            "slug": slug.current
+          }`,
+          { type },
+        ),
+      ),
+    );
+
+    for (let i = 0; i < CONTENT_TYPES.length; i++) {
+      const { label } = CONTENT_TYPES[i]!;
+      const docs = results[i]!.filter((d: SlugDoc) => d.slug);
+      if (docs.length === 0) continue;
+
+      lines.push(`## ${label}`);
+      lines.push("");
+      for (const doc of docs) {
+        const url = `${SITE_URL}${doc.slug}`;
+        const mdUrl = `${url}.md`;
+        lines.push(`- [${doc.title}](${url}) ([markdown](${mdUrl}))`);
+      }
+      lines.push("");
+    }
+  } catch (error) {
+    console.error("[sitemap-md] Error:", error);
+  }
+
+  lines.push("---");
+  lines.push(`*Generated: ${new Date().toISOString().split("T")[0]}*`);
+
+  return new Response(lines.join("\n"), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { sanityFetch } from "@workspace/sanity/live";
 import { queryBlogPaths, queryBlogSlugPageData } from "@workspace/sanity/query";
 import { notFound } from "next/navigation";
 
+import { CopyPageMenu } from "@/components/elements/copy-page-menu";
 import { RichText } from "@/components/elements/rich-text";
 import { SanityImage } from "@/components/elements/sanity-image";
 import { TableOfContent } from "@/components/elements/table-of-content";
@@ -93,7 +94,12 @@ export default async function BlogSlugPage({
         <main>
           <ArticleJsonLd article={data} />
           <header className="mb-8">
-            <h1 className="mt-2 font-bold text-4xl">{title}</h1>
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <h1 className="font-bold text-4xl">{title}</h1>
+              <div className="shrink-0">
+                <CopyPageMenu markdownPath={`/blog/${slug}.md`} />
+              </div>
+            </div>
             <p className="mt-4 text-lg text-muted-foreground">{description}</p>
           </header>
           {image && (

--- a/apps/web/src/components/elements/copy-page-menu.tsx
+++ b/apps/web/src/components/elements/copy-page-menu.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu";
+import {
+  ArrowUpRightIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  CopyIcon,
+  FileTextIcon,
+} from "lucide-react";
+import { useCallback, useState } from "react";
+
+interface CopyPageMenuProps {
+  markdownPath: string;
+}
+
+export function CopyPageMenu({ markdownPath }: CopyPageMenuProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      const res = await fetch(markdownPath);
+      const text = await res.text();
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard may not be available */
+    }
+  }, [markdownPath]);
+
+  return (
+    <div className="inline-flex items-center rounded-lg border border-border bg-background">
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex items-center gap-1.5 rounded-l-lg px-3 py-1 text-sm text-primary/85 transition-colors hover:bg-muted"
+      >
+        {copied ? (
+          <CheckIcon strokeWidth={1.5} className="size-4 text-green-500" />
+        ) : (
+          <CopyIcon strokeWidth={1.5} className="size-4" />
+        )}
+        <span className="relative grid items-center justify-items-start">
+          <span className="invisible col-start-1 row-start-1">Copy page</span>
+          <span className="invisible col-start-1 row-start-1">Copied!</span>
+          <span className="col-start-1 row-start-1">
+            {copied ? "Copied!" : "Copy page"}
+          </span>
+        </span>
+      </button>
+
+      <span className="w-px self-stretch bg-border" />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center rounded-r-lg px-2 py-2 text transition-colors hover:bg-muted focus:outline-none"
+          >
+            <ChevronDownIcon strokeWidth={1.5} className="size-3.5" />
+          </button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          alignOffset={10}
+          sideOffset={10}
+          className="w-72 rounded-xl p-1.5"
+        >
+          <DropdownMenuItem
+            onClick={handleCopy}
+            className="flex cursor-pointer items-start gap-3 rounded-lg"
+          >
+            <span className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-muted">
+              <CopyIcon strokeWidth={1.5} className="!size-5 text-muted-foreground" />
+            </span>
+            <span>
+              <span className="block text-sm font-semibold">Copy page</span>
+              <span className="block text-xs text-muted-foreground">
+                Copy page as Markdown for LLMs
+              </span>
+            </span>
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem
+            asChild
+            className="flex cursor-pointer items-start gap-3 rounded-lg"
+          >
+            <a href={markdownPath} target="_blank" rel="noopener noreferrer">
+              <span className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-muted">
+                <FileTextIcon
+                  strokeWidth={1.5}
+                  className="!size-5 text-muted-foreground"
+                />
+              </span>
+              <span>
+                <span className="inline-flex items-center gap-1 text-sm font-semibold">
+                  View as Markdown
+                  <ArrowUpRightIcon strokeWidth={1.5} className="!size-3.5" />
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  View this page as plain text
+                </span>
+              </span>
+            </a>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/src/lib/markdown/formatter.ts
+++ b/apps/web/src/lib/markdown/formatter.ts
@@ -1,0 +1,140 @@
+import { pageBuilderBlockToMarkdown } from "./pagebuilder-serializers";
+import { portableTextToMarkdown } from "./portable-text-serializers";
+import { normalizeMarkdownUrls } from "./url-normalizer";
+
+/**
+ * Convert a Sanity document to a clean markdown string.
+ * Handles title, description, metadata, PortableText body (richText),
+ * and pageBuilder blocks.
+ * @param documentData - Object with `type` (Sanity _type) and `data` (full document)
+ * @returns Clean markdown string with normalized absolute URLs
+ */
+export function formatDocumentAsMarkdown(documentData: {
+  type: string;
+  data: any;
+}): string {
+  const { data, type } = documentData;
+  const parts: string[] = [];
+
+  // 1. Title
+  if (data.title || data.name) {
+    parts.push(`# ${data.title || data.name}\n`);
+  }
+
+  // 2. Description as blockquote
+  const desc =
+    data.seoDescription || data.description || data.excerpt || data.summary;
+  if (desc && typeof desc === "string") {
+    parts.push(`> ${desc}\n`);
+  }
+
+  // 3. Metadata block
+  const meta: string[] = [];
+
+  const authorData = data.authors?.[0] || data.author;
+  if (authorData) {
+    const authorName =
+      typeof authorData === "string" ? authorData : authorData.name;
+    if (authorName) meta.push(`**Author:** ${authorName}`);
+  }
+
+  const pubDate =
+    data.publishedAt || data.date || data.pubDateTime || data._createdAt;
+  if (pubDate) {
+    const pubDateObj = new Date(pubDate);
+    if (!Number.isNaN(pubDateObj.getTime())) {
+      const date = pubDateObj.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+      meta.push(`**Published:** ${date}`);
+    }
+  }
+
+  const upDate = data._updatedAt || data.updatedAt;
+  if (upDate && pubDate) {
+    const upDateObj = new Date(upDate);
+    const pubDateObj = new Date(pubDate);
+    if (!Number.isNaN(upDateObj.getTime()) && !Number.isNaN(pubDateObj.getTime())) {
+      const updatedStr = upDateObj.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+      const pubStr = pubDateObj.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+      if (updatedStr !== pubStr) meta.push(`**Updated:** ${updatedStr}`);
+    }
+  }
+
+  if (data.topics && Array.isArray(data.topics)) {
+    const topicNames = data.topics
+      .map(
+        (t: any) => t?.title || t?.name || (typeof t === "string" ? t : null),
+      )
+      .filter(
+        (name: unknown): name is string =>
+          typeof name === "string" && name.length > 0,
+      );
+    if (topicNames.length > 0)
+      meta.push(`**Topics:** ${topicNames.join(", ")}`);
+  }
+
+  if (meta.length > 0) {
+    parts.push(meta.join("  \n") + "\n");
+  }
+
+  parts.push("---\n");
+
+  // 4. Main rich text body (PortableText)
+  const body = data.richText || data.body || data.content;
+  if (body && Array.isArray(body)) {
+    parts.push(portableTextToMarkdown(body));
+    parts.push("\n");
+  }
+
+  // 5. PageBuilder blocks
+  if (data.pageBuilder && Array.isArray(data.pageBuilder)) {
+    for (const block of data.pageBuilder) {
+      const blockMarkdown = pageBuilderBlockToMarkdown(block);
+      if (blockMarkdown.trim()) {
+        parts.push(`${blockMarkdown}\n`);
+      }
+    }
+  }
+
+  // 6. Blog listing (for blogIndex pages)
+  if (data.blogs && Array.isArray(data.blogs) && data.blogs.length > 0) {
+    parts.push("## Blog Posts\n");
+    for (const blog of data.blogs) {
+      const title = blog.title || "Untitled";
+      const slug = blog.slug || "";
+      const desc = blog.description || "";
+      const date = blog.publishedAt
+        ? new Date(blog.publishedAt).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          })
+        : "";
+      const dateSuffix = date ? ` (${date})` : "";
+      if (slug) {
+        parts.push(
+          `- [${title}](${slug})${dateSuffix}${desc ? ` — ${desc}` : ""}`,
+        );
+      }
+    }
+    parts.push("");
+  }
+
+  const markdown = parts
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return normalizeMarkdownUrls(markdown);
+}

--- a/apps/web/src/lib/markdown/pagebuilder-serializers.ts
+++ b/apps/web/src/lib/markdown/pagebuilder-serializers.ts
@@ -1,0 +1,170 @@
+import { portableTextToMarkdown } from "./portable-text-serializers";
+
+/**
+ * Convert a single Sanity pageBuilder block to markdown.
+ * Falls back to generic text extraction for unknown block types.
+ * @param block - A single block from pageBuilder[]
+ * @returns Markdown string for this block
+ */
+export function pageBuilderBlockToMarkdown(block: any): string {
+  switch (block._type) {
+    case "hero":
+      return convertHeroBlock(block);
+
+    case "cta":
+      return convertCtaBlock(block);
+
+    case "faqAccordion":
+      return convertFaqAccordionBlock(block);
+
+    case "featureCardsIcon":
+      return convertFeatureCardsIconBlock(block);
+
+    case "imageLinkCards":
+      return convertImageLinkCardsBlock(block);
+
+    case "subscribeNewsletter":
+      return convertSubscribeNewsletterBlock(block);
+
+    default:
+      return extractTextContent(block);
+  }
+}
+
+function convertHeroBlock(block: any): string {
+  const parts: string[] = [];
+  if (block.title) parts.push(`# ${block.title}`);
+  if (block.subtitle && typeof block.subtitle === "string") {
+    parts.push(block.subtitle);
+  }
+  if (block.richText) parts.push(portableTextToMarkdown(block.richText));
+  return parts.join("\n\n") + "\n\n---\n";
+}
+
+function convertCtaBlock(block: any): string {
+  const parts: string[] = [];
+  if (block.title) parts.push(`## ${block.title}`);
+  if (block.richText) parts.push(portableTextToMarkdown(block.richText));
+  return parts.join("\n\n") + "\n\n---\n";
+}
+
+function convertFaqAccordionBlock(block: any): string {
+  const parts: string[] = [];
+  if (block.title) parts.push(`## ${block.title}`);
+  if (block.subtitle && typeof block.subtitle === "string") {
+    parts.push(block.subtitle);
+  }
+  const faqs = block.faqs || [];
+  for (const faq of faqs) {
+    if (faq.title) parts.push(`\n**${faq.title}**`);
+    if (faq.richText) {
+      parts.push(portableTextToMarkdown(faq.richText));
+    }
+  }
+  return parts.join("\n") + "\n\n";
+}
+
+function convertFeatureCardsIconBlock(block: any): string {
+  const parts: string[] = [];
+  if (block.title) parts.push(`## ${block.title}`);
+  if (block.richText) parts.push(portableTextToMarkdown(block.richText));
+  const cards = block.cards || [];
+  for (const card of cards) {
+    const name = card.title || "";
+    const desc = card.richText
+      ? portableTextToMarkdown(card.richText)
+      : typeof card.description === "string"
+        ? card.description
+        : "";
+    if (name) parts.push(`- **${name}**${desc ? `: ${desc}` : ""}`);
+  }
+  return parts.join("\n\n") + "\n\n";
+}
+
+function convertImageLinkCardsBlock(block: any): string {
+  const parts: string[] = [];
+  if (block.title) parts.push(`## ${block.title}`);
+  if (block.richText) parts.push(portableTextToMarkdown(block.richText));
+  const cards = block.cards || [];
+  for (const card of cards) {
+    const name = card.title || "";
+    const desc =
+      typeof card.description === "string" ? card.description : "";
+    const href = card.href || "";
+    if (name && href) {
+      parts.push(`- [**${name}**](${href})${desc ? `: ${desc}` : ""}`);
+    } else if (name) {
+      parts.push(`- **${name}**${desc ? `: ${desc}` : ""}`);
+    }
+  }
+  return parts.join("\n\n") + "\n\n";
+}
+
+function convertSubscribeNewsletterBlock(block: any): string {
+  const parts: string[] = [];
+  if (block.title) parts.push(`## ${block.title}`);
+  if (block.subTitle && Array.isArray(block.subTitle)) {
+    parts.push(portableTextToMarkdown(block.subTitle));
+  }
+  return parts.join("\n\n") + "\n\n";
+}
+
+/**
+ * Generic fallback: walk the block and pull out readable strings.
+ * Skips image data, asset refs, and internal Sanity metadata keys.
+ */
+function extractTextContent(block: any): string {
+  const text: string[] = [];
+  const SKIP_FIELDS = new Set([
+    "_key",
+    "_type",
+    "_id",
+    "_ref",
+    "lqip",
+    "preview",
+    "metadata",
+    "asset",
+    "hotspot",
+    "crop",
+    "image",
+    "images",
+    "logo",
+    "icon",
+    "alt",
+    "caption",
+    "palette",
+    "dimensions",
+  ]);
+
+  function walk(obj: any, depth = 0): void {
+    if (depth > 5) return;
+    if (typeof obj === "string") {
+      if (
+        obj.length < 500 &&
+        !obj.startsWith("data:image") &&
+        !obj.startsWith("image-") &&
+        !obj.startsWith("http") &&
+        !obj.includes("sanity.io")
+      ) {
+        text.push(obj);
+      }
+    } else if (Array.isArray(obj)) {
+      for (const item of obj) walk(item, depth + 1);
+    } else if (obj && typeof obj === "object") {
+      if (obj._type === "block" || Array.isArray(obj.children)) {
+        const pt = portableTextToMarkdown([obj]);
+        if (pt && pt.length < 500) text.push(pt);
+      } else {
+        for (const [key, value] of Object.entries(obj)) {
+          if (!SKIP_FIELDS.has(key)) walk(value, depth + 1);
+        }
+      }
+    }
+  }
+
+  walk(block);
+  return Array.from(new Set(text))
+    .filter((t) => t.trim().length > 0)
+    .join("\n\n")
+    .trim();
+}

--- a/apps/web/src/lib/markdown/pagebuilder-serializers.ts
+++ b/apps/web/src/lib/markdown/pagebuilder-serializers.ts
@@ -136,16 +136,23 @@ function extractTextContent(block: any): string {
     "dimensions",
   ]);
 
+  function isSanityAssetOrUrl(value: string): boolean {
+    if (value.startsWith("data:image") || value.startsWith("image-")) {
+      return true;
+    }
+    try {
+      const url = new URL(value);
+      if (url.protocol === "http:" || url.protocol === "https:") return true;
+    } catch {
+      // Not a URL — treat as text
+    }
+    return false;
+  }
+
   function walk(obj: any, depth = 0): void {
     if (depth > 5) return;
     if (typeof obj === "string") {
-      if (
-        obj.length < 500 &&
-        !obj.startsWith("data:image") &&
-        !obj.startsWith("image-") &&
-        !obj.startsWith("http") &&
-        !obj.includes("sanity.io")
-      ) {
+      if (obj.length < 500 && !isSanityAssetOrUrl(obj)) {
         text.push(obj);
       }
     } else if (Array.isArray(obj)) {

--- a/apps/web/src/lib/markdown/portable-text-serializers.ts
+++ b/apps/web/src/lib/markdown/portable-text-serializers.ts
@@ -61,11 +61,12 @@ export function portableTextToMarkdown(
         const headers = rows[0]?.cells;
         if (!headers || !Array.isArray(headers)) return "";
         const dataRows = rows.slice(1);
-        let table = `| ${headers.join(" | ")} |\n`;
+        const esc = (s: string) => s.replace(/\|/g, "\\|");
+        let table = `| ${headers.map(esc).join(" | ")} |\n`;
         table += `| ${headers.map(() => "---").join(" | ")} |\n`;
         for (const row of dataRows) {
           if (row?.cells && Array.isArray(row.cells)) {
-            table += `| ${row.cells.join(" | ")} |\n`;
+            table += `| ${row.cells.map(esc).join(" | ")} |\n`;
           }
         }
         return `\n${table}\n`;

--- a/apps/web/src/lib/markdown/portable-text-serializers.ts
+++ b/apps/web/src/lib/markdown/portable-text-serializers.ts
@@ -61,7 +61,8 @@ export function portableTextToMarkdown(
         const headers = rows[0]?.cells;
         if (!headers || !Array.isArray(headers)) return "";
         const dataRows = rows.slice(1);
-        const esc = (s: string) => s.replace(/\|/g, "\\|");
+        const esc = (s: string) =>
+          s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
         let table = `| ${headers.map(esc).join(" | ")} |\n`;
         table += `| ${headers.map(() => "---").join(" | ")} |\n`;
         for (const row of dataRows) {

--- a/apps/web/src/lib/markdown/portable-text-serializers.ts
+++ b/apps/web/src/lib/markdown/portable-text-serializers.ts
@@ -1,0 +1,81 @@
+import { portableTextToMarkdown as ptToMd } from "@portabletext/markdown";
+
+const PROJECT_ID = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "";
+const DATASET = process.env.NEXT_PUBLIC_SANITY_DATASET || "production";
+
+/**
+ * Parse a Sanity asset reference (e.g. "image-abc123-1200x800-jpg")
+ * into a CDN URL.
+ */
+function assetRefToUrl(ref: string): string | null {
+  const match = ref.match(/^image-([a-zA-Z0-9]+)-(\d+x\d+)-(\w+)$/);
+  if (!match) return null;
+  const [, id, , ext] = match;
+  return `https://cdn.sanity.io/images/${PROJECT_ID}/${DATASET}/${id}.${ext}`;
+}
+
+/**
+ * Resolve the best available image URL from a Sanity image value.
+ * Handles both expanded asset objects and projected `id` (asset._ref).
+ */
+function resolveImageUrl(value: any): string | null {
+  if (value?.asset?.url) return value.asset.url;
+  if (value?.url) return value.url;
+  if (value?.id && typeof value.id === "string") return assetRefToUrl(value.id);
+  if (value?.asset?._ref) return assetRefToUrl(value.asset._ref);
+  return null;
+}
+
+/**
+ * Convert a PortableText array to a markdown string.
+ * Handles standard blocks plus custom inline block types.
+ * @param blocks - PortableText blocks from Sanity
+ * @returns Markdown string
+ */
+export function portableTextToMarkdown(
+  blocks: any[] | null | undefined,
+): string {
+  if (!blocks || blocks.length === 0) return "";
+
+  return ptToMd(blocks, {
+    marks: {
+      customLink: ({ children, value }: any) => {
+        const href = value?.href || "#";
+        return `[${children}](${href})`;
+      },
+      code: ({ children }: any) => `\`${children}\``,
+    },
+    types: {
+      image: ({ value }: any) => {
+        const alt = value?.alt || "Image";
+        const caption = value?.caption || "";
+        const url = resolveImageUrl(value);
+        if (!url) return "";
+        return caption
+          ? `![${alt}](${url})\n\n*${caption}*\n`
+          : `![${alt}](${url})\n`;
+      },
+      table: ({ value }: any) => {
+        if (!value?.rows || value.rows.length === 0) return "";
+        const rows = value.rows;
+        const headers = rows[0]?.cells;
+        if (!headers || !Array.isArray(headers)) return "";
+        const dataRows = rows.slice(1);
+        let table = `| ${headers.join(" | ")} |\n`;
+        table += `| ${headers.map(() => "---").join(" | ")} |\n`;
+        for (const row of dataRows) {
+          if (row?.cells && Array.isArray(row.cells)) {
+            table += `| ${row.cells.join(" | ")} |\n`;
+          }
+        }
+        return `\n${table}\n`;
+      },
+      codeBlock: ({ value }: any) => {
+        const lang = value?.code?.language || "";
+        const code = value?.code?.code || "";
+        return `\`\`\`${lang}\n${code}\n\`\`\``;
+      },
+      buttons: () => "",
+    },
+  });
+}

--- a/apps/web/src/lib/markdown/url-normalizer.ts
+++ b/apps/web/src/lib/markdown/url-normalizer.ts
@@ -14,5 +14,8 @@ const SITE_URL =
  * @returns Markdown with all links made absolute
  */
 export function normalizeMarkdownUrls(markdown: string): string {
-  return markdown.replace(/\[([^\]]+)\]\(\/([^)]+)\)/g, `[$1](${SITE_URL}/$2)`);
+  return markdown.replace(
+    /\[([^\]]+)\]\(\/((?:[^()]*|\([^()]*\))*)\)/g,
+    `[$1](${SITE_URL}/$2)`,
+  );
 }

--- a/apps/web/src/lib/markdown/url-normalizer.ts
+++ b/apps/web/src/lib/markdown/url-normalizer.ts
@@ -1,0 +1,18 @@
+/**
+ * Normalize URLs in markdown content for AI agent consumption.
+ * Converts relative internal links to absolute URLs.
+ */
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
+    : "http://localhost:3000";
+
+/**
+ * Normalize relative URLs to absolute URLs in markdown.
+ * @param markdown - Markdown content with relative links
+ * @returns Markdown with all links made absolute
+ */
+export function normalizeMarkdownUrls(markdown: string): string {
+  return markdown.replace(/\[([^\]]+)\]\(\/([^)]+)\)/g, `[$1](${SITE_URL}/$2)`);
+}

--- a/apps/web/src/lib/markdown/url-normalizer.ts
+++ b/apps/web/src/lib/markdown/url-normalizer.ts
@@ -15,7 +15,7 @@ const SITE_URL =
  */
 export function normalizeMarkdownUrls(markdown: string): string {
   return markdown.replace(
-    /\[([^\]]+)\]\(\/((?:[^()]*|\([^()]*\))*)\)/g,
+    /\[([^\]]+)\]\(\/((?:\([^()]*\)|[^()])*)\)/g,
     `[$1](${SITE_URL}/$2)`,
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@portabletext/markdown':
+        specifier: ^1.1.2
+        version: 1.1.2
       '@sanity/asset-utils':
         specifier: ^2.3.0
         version: 2.3.0
@@ -4176,6 +4179,7 @@ packages:
 
   friendlier-words@1.1.3:
     resolution: {integrity: sha512-OVYGHh7UETIonK8WWplE0BFQTJGwI+i4GOESuA/wXchTGUBPFtb9AYuJwYGvcNY1YDRE3um4HezKdozvo2PUmw==}
+    deprecated: This package has been renamed to joyful. You can install it with npm i joyful
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -9545,7 +9549,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@sanity/insert-menu@3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@sanity/insert-menu@3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8)(debug@4.4.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.3)
       '@sanity/types': 5.7.0(@types/react@19.2.8)(debug@4.4.3)
@@ -9954,7 +9958,7 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.3)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8)(debug@4.4.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.25.1)
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.0)(@sanity/types@5.7.0(@types/react@19.2.8))
       '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.0)
@@ -9981,7 +9985,7 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.3)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8)(debug@4.4.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.25.1)
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.0)(@sanity/types@5.7.0(@types/react@19.2.8))
       '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.0)
@@ -13327,7 +13331,7 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 2.0.3
       '@sanity/import': 4.1.0(@types/node@24.10.9)(@types/react@19.2.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(yaml@2.6.1)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8)(debug@4.4.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@sanity/logos': 2.2.2(react@19.2.3)
       '@sanity/media-library-types': 1.2.0
       '@sanity/message-protocol': 0.19.0
@@ -13504,7 +13508,7 @@ snapshots:
       '@sanity/id-utils': 1.0.0
       '@sanity/image-url': 2.0.3
       '@sanity/import': 4.1.0(@types/node@24.10.9)(@types/react@19.2.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.37.0)(yaml@2.6.1)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.7.0(@types/react@19.2.8)(debug@4.4.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(styled-components@6.3.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@sanity/logos': 2.2.2(react@19.2.3)
       '@sanity/media-library-types': 1.2.0
       '@sanity/message-protocol': 0.19.0


### PR DESCRIPTION
# ⏺ feat: add markdown routes, llms.txt, and CopyPageMenu for LLM accessibility

  Description

  Adds an LLM-friendly markdown layer to the website. Every page now has a parallel .md route that
  converts Sanity content (PortableText body + PageBuilder blocks) into clean, readable markdown. An
  /llms.txt discovery endpoint lets AI agents find all available content, and a /sitemap.md provides a
  full content index.

  On the frontend, blog posts get a CopyPageMenu split-button that lets users copy the full page as
  markdown or grab the .md URL directly — useful for pasting into AI tools, docs, or note-taking apps.

  What changed

  Markdown conversion library (src/lib/markdown/)
  - formatter.ts — orchestrates title, metadata, PortableText body, PageBuilder blocks, and blog
  listings into structured markdown
  - portable-text-serializers.ts — converts PortableText to markdown with Sanity image CDN URL
  resolution (parses image-{id}-{dims}-{ext} asset refs)
  - pagebuilder-serializers.ts — serializes 6 block types (hero, CTA, FAQ accordion, feature cards,
  image link cards, newsletter) with generic fallback
  - url-normalizer.ts — converts relative URLs to absolute using production domain

  API routes (src/app/api/)
  - md/[...path]/route.ts — dynamic markdown route with document type detection, singleton handling
  (homePage, blogIndex), and blog post injection
  - md/route.ts — homepage markdown endpoint
  - llms-txt/route.ts — LLM agent discovery file listing all .md URLs
  - sitemap-md/route.ts — content sitemap with all page URLs

  Next.js config
  - Added rewrites: /.md, /:path+.md, /llms.txt, /sitemap.md → corresponding API routes

  CopyPageMenu component (src/components/elements/copy-page-menu.tsx)
  - Split-button: left side copies full page markdown, dropdown offers "Copy .md URL"
  - CSS grid overlay technique prevents layout shift when text changes to "Copied!"
  - Mobile-responsive: button drops below title on small screens

  Blog page (src/app/blog/[slug]/page.tsx)
  - Added CopyPageMenu with flex-col md:flex-row responsive layout

  Test plan

  - /.md — renders homepage markdown
  - /blog.md — lists all blog posts with titles, dates, and links
  - /blog/<any-slug>.md — full blog post with working image CDN URLs (no ![untitled]([image]))
  - /<any-page>.md — renders PageBuilder block content
  - /llms.txt — lists all available .md URLs
  - /sitemap.md — lists all page URLs
  - /nonexistent-page.md — returns 404
  - Click "Copy page" on blog post — copies markdown to clipboard, no width shift
  - Click dropdown → "Copy .md URL" — copies the .md URL
  - Mobile: button renders on its own line below the title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View pages, posts and the homepage as Markdown via new .md endpoints.
  * New llms.txt and sitemap.md endpoints for site discovery.
  * In-page "Copy page" menu to copy Markdown or open it in a new tab.

* **Enhancements**
  * Richer Markdown rendering: page-builder blocks, images, tables, code, and normalized absolute links.
  * Blog header now shows the copy menu next to the title.

* **Chores**
  * Added a Markdown conversion dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->