### PR TITLE
fix: remove unsupported token input from template validator

### DIFF
--- a/.github/workflows/sanity-template.yml
+++ b/.github/workflows/sanity-template.yml
@@ -14,5 +14,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate Sanity Template
         uses: sanity-io/template-validator@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Reverts the token input added in #371 — the action doesn't support it
- The previous failure was a transient GitHub API issue, not a rate limit

## Test plan
- [ ] Verify Validate Template passes on merge to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated template validation workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->