### PR TITLE
fix: prevent empty generateStaticParams build failure on fresh installs

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -16,6 +16,8 @@ import { getSEOMetadata } from "@/lib/seo";
 
 const logger = new Logger("PageSlug");
 
+const PLACEHOLDER_SLUG = "__placeholder__";
+
 type SlugParams = { slug: string[] };
 
 export async function generateStaticParams() {
@@ -25,7 +27,7 @@ export async function generateStaticParams() {
     });
 
     if (!Array.isArray(slugs) || slugs.length === 0) {
-      return [];
+      return [{ slug: [PLACEHOLDER_SLUG] }];
     }
 
     const paths: SlugParams[] = [];
@@ -39,8 +41,7 @@ export async function generateStaticParams() {
     return paths;
   } catch (error) {
     logger.error("Error fetching slug paths", error);
-    // Return empty array to allow build to continue
-    return [];
+    return [{ slug: [PLACEHOLDER_SLUG] }];
   }
 }
 

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -19,6 +19,8 @@ import { getSEOMetadata } from "@/lib/seo";
 
 const logger = new Logger("BlogSlug");
 
+const PLACEHOLDER_SLUG = "__placeholder__";
+
 type BlogParams = { slug: string };
 
 export async function generateStaticParams() {
@@ -28,7 +30,7 @@ export async function generateStaticParams() {
     });
 
     if (!Array.isArray(slugs) || slugs.length === 0) {
-      return [];
+      return [{ slug: PLACEHOLDER_SLUG }];
     }
 
     const paths: BlogParams[] = [];
@@ -44,8 +46,7 @@ export async function generateStaticParams() {
     return paths;
   } catch (error) {
     logger.error("Error fetching blog paths", error);
-    // Return empty array to allow build to continue
-    return [];
+    return [{ slug: PLACEHOLDER_SLUG }];
   }
 }
 


### PR DESCRIPTION
## What

Fresh installs with an empty Sanity dataset failed to build:

```
Error [EmptyGenerateStaticParamsError]: When using Cache Components, all `generateStaticParams` functions must return at least one result.
```

`apps/web/next.config.ts` sets `cacheComponents: true`, which requires every `generateStaticParams` to return at least one entry. Both `[...slug]` and `blog/[slug]` returned `[]` when the dataset was empty (or a fetch errored), so the build died before any content could exist.

## Fix

Return a `__placeholder__` slug instead of an empty array. Each page already calls `notFound()` when its data is missing, so the placeholder resolves to a static 404 with no extra handling — and `notFound()` stays outside the `'use cache'` boundary, as before.

```diff
     if (!Array.isArray(slugs) || slugs.length === 0) {
-      return [];
+      return [{ slug: [PLACEHOLDER_SLUG] }];
     }
```

## Verify

- `pnpm check-types` — passes
- `pnpm build:web` — 44/44 pages, no `EmptyGenerateStaticParamsError`

## Demo

This fix is build-time, so runtime looks the same — but the clean 404 at the end of this clip is the `notFound()` path the placeholder resolves to:

![404 path](https://github.com/robotostudio/turbo-start-sanity/releases/download/pr-media/turbo-start-upgrade-demo.gif)

Fixes #379.
