### PR TITLE
fix: source SEO site title from Settings instead of hardcoding

### DIFF
--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,3 +1,8 @@
+import {
+  getDynamicFetchOptions,
+  sanityFetchMetadata,
+} from "@workspace/sanity/live";
+import { queryGlobalSeoSettings } from "@workspace/sanity/query";
 import type { Metadata } from "next";
 
 import type { Maybe } from "@/types";
@@ -29,13 +34,32 @@ type OgImageParams = {
   id?: string;
 };
 
-// Default site configuration
-const siteConfig: SiteConfig = {
+// Fallbacks used until the Settings document is populated in the Studio
+const FALLBACK_SITE_CONFIG: SiteConfig = {
   title: "Roboto Studio Demo",
   description: "Roboto Studio Demo",
   twitterHandle: "@studioroboto",
   keywords: ["roboto", "studio", "demo", "sanity", "next", "react", "template"],
 };
+
+// Pulls site-wide config from the Sanity Settings document, with fallbacks
+async function resolveSiteConfig(): Promise<SiteConfig> {
+  const { perspective } = await getDynamicFetchOptions();
+  const { data: settings } = await sanityFetchMetadata({
+    query: queryGlobalSeoSettings,
+    perspective,
+  });
+  const twitter = settings?.socialLinks?.twitter
+    ?.split("/")
+    .filter(Boolean)
+    .pop();
+  return {
+    title: settings?.siteTitle || FALLBACK_SITE_CONFIG.title,
+    description: settings?.siteDescription || FALLBACK_SITE_CONFIG.description,
+    twitterHandle: twitter ? `@${twitter}` : FALLBACK_SITE_CONFIG.twitterHandle,
+    keywords: FALLBACK_SITE_CONFIG.keywords,
+  };
+}
 
 function generateOgImageUrl(params: OgImageParams = {}): string {
   const { type, id } = params;
@@ -81,7 +105,9 @@ function extractTitle({
   return siteTitle;
 }
 
-export function getSEOMetadata(page: PageSeoData = {}): Metadata {
+export async function getSEOMetadata(
+  page: PageSeoData = {}
+): Promise<Metadata> {
   const {
     title: pageTitle,
     description: pageDescription,
@@ -94,6 +120,7 @@ export function getSEOMetadata(page: PageSeoData = {}): Metadata {
     ...pageOverrides
   } = page;
 
+  const siteConfig = await resolveSiteConfig();
   const baseUrl = getBaseUrl();
   const pageUrl = buildPageUrl({ baseUrl, slug });
 


### PR DESCRIPTION
## What

`getSEOMetadata` was refactored into a synchronous helper with a hardcoded `siteConfig` ("Roboto Studio Demo"), so the **Site Title**, description, and social handle set in the Studio's Settings were ignored in page metadata. This reintroduced the original bug (#69, fixed in #94) after #162.

## Fix

Make `getSEOMetadata` async and resolve the site config from the Settings document via the existing `queryGlobalSeoSettings` — the same query the footer and navbar already fetch — keeping the old values as fallbacks for an unpopulated dataset. The four `generateMetadata` callers already `return getSEOMetadata(...)` from async context, so there are no call-site changes.

## Before / after

Same dataset, whose configured `siteTitle` is "Template Roboto Next Sanity":

| Page | Before | After |
| --- | --- | --- |
| home | `Home Page \| Roboto Studio Demo` | `Home Page \| Template Roboto Next Sanity` |
| blog post | `… \| Roboto Studio Demo` | `Secured Systematic Capacity! \| Template Roboto Next Sanity` |
| blog index | `… \| Roboto Studio Demo` | `Insights & Updates \| Template Roboto Next Sanity` |

`twitter:creator` falls back to `@studioroboto` only when no Twitter URL is set in Settings.

## Notes

- `keywords` stays a default constant — there is no keywords field in the Settings schema.
- The OG-image route doesn't hardcode the site title, so it's untouched.

## Verify

- `pnpm check-types` — 5/5
- `pnpm build:web` — 44/44 pages
- Rendered `<title>` now reflects the Studio Site Title (table above)

Fixes #380.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * SEO configuration is now dynamically managed and can be updated independently from the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->