### PR TITLE
fix: clear SonarCloud new-code issues (S6440 fixture + S6759 readonly props)

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -72,9 +72,9 @@ export async function generateMetadata({
 
 export default async function SlugPage({
   params,
-}: {
+}: Readonly<{
   params: Promise<SlugParams>;
-}) {
+}>) {
   const { isEnabled: isDraftMode } = await draftMode();
   if (isDraftMode) {
     return (
@@ -95,7 +95,9 @@ export default async function SlugPage({
   return <SlugPageContent pageData={pageData} />;
 }
 
-async function DynamicSlugPage({ params }: { params: Promise<SlugParams> }) {
+async function DynamicSlugPage({
+  params,
+}: Readonly<{ params: Promise<SlugParams> }>) {
   const [{ slug }, { perspective, stega }] = await Promise.all([
     params,
     getDynamicFetchOptions(),
@@ -126,9 +128,9 @@ async function getCachedSlugPage({
 
 function SlugPageContent({
   pageData,
-}: {
+}: Readonly<{
   pageData: NonNullable<Awaited<ReturnType<typeof getCachedSlugPage>>>;
-}) {
+}>) {
   const { title, pageBuilder, _id, _type } = pageData ?? {};
 
   return !Array.isArray(pageBuilder) || pageBuilder?.length === 0 ? (

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -77,9 +77,9 @@ export async function generateMetadata({
 
 export default async function BlogSlugPage({
   params,
-}: {
+}: Readonly<{
   params: Promise<BlogParams>;
-}) {
+}>) {
   const { isEnabled: isDraftMode } = await draftMode();
   if (isDraftMode) {
     return (
@@ -100,7 +100,9 @@ export default async function BlogSlugPage({
   return <BlogPageContent data={data} />;
 }
 
-async function DynamicBlogPage({ params }: { params: Promise<BlogParams> }) {
+async function DynamicBlogPage({
+  params,
+}: Readonly<{ params: Promise<BlogParams> }>) {
   const [{ slug }, { perspective, stega }] = await Promise.all([
     params,
     getDynamicFetchOptions(),
@@ -131,9 +133,9 @@ async function getCachedBlogPage({
 
 function BlogPageContent({
   data,
-}: {
+}: Readonly<{
   data: NonNullable<Awaited<ReturnType<typeof getCachedBlogPage>>>;
-}) {
+}>) {
   const { title, description, image, richText } = data ?? {};
 
   return (

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -85,7 +85,9 @@ type BlogPageProps = {
   }>;
 };
 
-export default function BlogIndexPage({ searchParams }: BlogPageProps) {
+export default function BlogIndexPage({
+  searchParams,
+}: Readonly<BlogPageProps>) {
   return (
     <Suspense fallback={<BlogIndexFallback />}>
       <DynamicBlogIndex searchParams={searchParams} />
@@ -93,7 +95,7 @@ export default function BlogIndexPage({ searchParams }: BlogPageProps) {
   );
 }
 
-async function DynamicBlogIndex({ searchParams }: BlogPageProps) {
+async function DynamicBlogIndex({ searchParams }: Readonly<BlogPageProps>) {
   const [{ page }, { perspective, stega }] = await Promise.all([
     searchParams,
     getDynamicFetchOptions(),

--- a/apps/web/tests/e2e/fixtures.ts
+++ b/apps/web/tests/e2e/fixtures.ts
@@ -31,13 +31,13 @@ function sanitizeSlugs(slugs: string[]): string[] {
 }
 
 export const test = base.extend<{ slugPages: SlugPages }>({
-  slugPages: async ({}, use) => {
+  slugPages: async ({}, provide) => {
     const result = await sanityClient.fetch<SlugPages>(`{
       "pages": *[_type == "page" && defined(slug.current)].slug.current,
       "blogs": *[_type == "blog" && defined(slug.current)].slug.current
     }`);
 
-    await use({
+    await provide({
       pages: sanitizeSlugs(result.pages ?? []),
       blogs: sanitizeSlugs(result.blogs ?? []),
     });


### PR DESCRIPTION
## What

Clears the SonarCloud **new-code** issues flagged on this work — both the gate-failing reliability bug and the maintainability issues raised on #378.

### Reliability — `S6440` (`apps/web/tests/e2e/fixtures.ts`)
Sonar's react-hooks rule treats any `use`-prefixed callback called outside a component as a misused React Hook, and flagged Playwright's fixture `use` argument. Renamed it to `provide` — a plain name that isn't hook-shaped — which sidesteps the rule.

> Note: an initial `use` → `useFixture` rename did **not** work — `use*` still matches React's custom-hook naming convention, so Sonar kept flagging it. `provide` is the correct fix.

### Maintainability — `S6759` (the 6 issues on #378, + 2 sibling components)
Marked React component props `Readonly<>` in `[...slug]/page.tsx`, `blog/[slug]/page.tsx`, and `blog/page.tsx` (the page, dynamic, and content components — clearing the reported six plus the two `*PageContent` components that share the pattern).

## Verify

- `pnpm check-types` — 5/5
- `pnpm build:web` — passes

## Note on the duplication gate condition

`main`'s other gate failure — **Duplication (11.5%)** — is the generated `packages/sanity/src/sanity.types.ts`, not hand-written code. It needs a UI exclusion (Project → Administration → Analysis Scope), since SonarCloud Automatic Analysis ignores the committed `sonar-project.properties`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test fixture for clearer parameter handling and query formatting to enhance test reliability.
* **Refactor**
  * Strengthened component prop immutability annotations to improve type safety and maintainability without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->