### PR TITLE
restore SanityLive tag invalidation for non-preview visitors

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,6 +21,7 @@ import { Navbar, NavbarSkeleton } from "@/components/navbar";
 import { PreviewBar } from "@/components/preview-bar";
 import { Providers } from "@/components/providers";
 import { getNavigationData } from "@/lib/navigation";
+import { sanityLiveAction } from "@/lib/sanity-live-action";
 
 const fontSans = Geist({
   subsets: ["latin"],
@@ -61,7 +62,7 @@ export default async function RootLayout({
           ) : (
             <CachedFooter perspective="published" stega={false} />
           )}
-          <SanityLive includeDrafts={isDraftMode} />
+          <SanityLive action={sanityLiveAction} includeDrafts={isDraftMode} />
           <CombinedJsonLd includeOrganization includeWebsite />
           {isDraftMode && (
             <>

--- a/apps/web/src/lib/sanity-live-action.ts
+++ b/apps/web/src/lib/sanity-live-action.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { revalidateTag, updateTag } from "next/cache";
+import { draftMode } from "next/headers";
+import { parseTags } from "next-sanity/live";
+
+// Invalidate cache tags on live events so non-preview visitors see edits without refresh.
+export async function sanityLiveAction(unsafeTags: unknown) {
+  const { isEnabled: isDraftMode } = await draftMode();
+  const { tags } = parseTags(unsafeTags);
+  for (const tag of tags) {
+    if (isDraftMode) {
+      revalidateTag(tag, "max");
+    } else {
+      updateTag(tag);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

After cache component changes, regular site visitors (no preview token, no draft mode) no longer see Sanity content edits propagate automatically — they have to refresh the page. This restores the pre-v13 behaviour by passing a custom `action` to `<SanityLive>` that invalidates the right cache tags on each live event.

## Changes

**New — `apps/web/src/lib/sanity-live-action.ts`**

- file-level `"use server"` server action
- parses the live event's sync tags with `parseTags`
- for each tag, invalidates based on draft state:
  - non-draft → `updateTag(tag)`
  - draft mode → `revalidateTag(tag, "max")`

**Updated — `apps/web/src/app/layout.tsx`**

- import `sanityLiveAction`
- pass it to `<SanityLive>`: `<SanityLive action={sanityLiveAction} includeDrafts={isDraftMode} />`

## Why

next-sanity v13 changed `<SanityLive>`'s default action to `refresh()`. Per the Next.js 16.2 source, `refresh()` "only revalidates the dynamic data on the client. It doesn't affect cached data." So cached pages kept serving the old content to non-preview visitors — never re-fetching even though the live event fired. The custom action runs `updateTag`/`revalidateTag` server-side first, so the next render gets fresh data.

## Verification

- `pnpm check-types` — ✅ pass (5/5 packages)
- `pnpm lint` — ✅ pass (6/6 packages)
- `pnpm build:web` — ✅ exit 0, "Cache Components enabled"

**Manual check (open two windows):**

1. Window A — open `localhost:3000/` in a normal tab (no preview).
2. Window B — open Sanity Studio, edit and publish a change to the home page.
3. Window A should update within a few seconds without a manual refresh.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced real-time content synchronization for draft and published content states. Live updates now properly handle both content modes, ensuring changes are reflected immediately across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->