### PR TITLE
Add plain definition paragraph to README top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Turbo Start Sanity
 
+Turbo Start Sanity is a free, open-source Sanity template: a Next.js page builder
+starter with visual editing, hyper-optimised SEO, and a Turborepo monorepo structure.
+Built by [Roboto Studio](https://robotostudio.com) and used in production client builds.
+
 ![Turbo Start Sanity](https://raw.githubusercontent.com/robotostudio/turbo-start-sanity/main/tasteful-safe-option-og.png)
 
 ## A bare-metal, nitro-fuelled Sanity template welded in the garage of Roboto Studio. Ready to rip with pagebuilders, hyper-optimised SEO, and a need for speed.


### PR DESCRIPTION
Adds a self-contained one-paragraph definition above the existing flavor copy: what the template is, who it's for, with the page builder and Sanity template phrasings AI extraction and search look for in the first 60 words. Adds a robotostudio.com backlink. The flavor copy stays.

Fixes part of ROB-2081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project introduction in README with a description of key features including Next.js page builder, visual editing capabilities, SEO focus, and monorepo structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->