### PR TITLE
ROB-2081: link README to /services/sanity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Turbo Start Sanity is a free, open-source Sanity template: a Next.js page builder
 starter with visual editing, hyper-optimised SEO, and a Turborepo monorepo structure.
-Built by [Roboto Studio](https://robotostudio.com) and used in production client builds.
+Built by [Roboto Studio](https://robotostudio.com/services/sanity) and used in production client builds.
 
 ![Turbo Start Sanity](https://raw.githubusercontent.com/robotostudio/turbo-start-sanity/main/tasteful-safe-option-og.png)
 


### PR DESCRIPTION
Points the README's Roboto Studio credit at https://robotostudio.com/services/sanity for ROB-2081 (GitHub visibility / AI indexability).