### PR TITLE
fix: restore page-builder block styling and unblock JSON-LD

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -63,7 +63,9 @@ export default async function RootLayout({
             <CachedFooter perspective="published" stega={false} />
           )}
           <SanityLive action={sanityLiveAction} includeDrafts={isDraftMode} />
-          <CombinedJsonLd includeOrganization includeWebsite />
+          <Suspense fallback={null}>
+            <CombinedJsonLd includeOrganization includeWebsite />
+          </Suspense>
           {isDraftMode && (
             <>
               <PreviewBar />

--- a/packages/sanity-blocks/src/cta/index.tsx
+++ b/packages/sanity-blocks/src/cta/index.tsx
@@ -18,7 +18,7 @@ export function CTABlock({
   buttons,
 }: Readonly<CtaBlockProps>) {
   return (
-    <section className="my-6 md:my-16" id="features">
+    <section className="my-6 md:my-16" id="cta">
       <div className="container mx-auto px-4 md:px-8">
         <div className="rounded-3xl bg-muted px-4 py-16">
           <div className="mx-auto max-w-3xl space-y-8 text-center">

--- a/packages/sanity-blocks/src/feature-cards-icon/index.tsx
+++ b/packages/sanity-blocks/src/feature-cards-icon/index.tsx
@@ -21,9 +21,11 @@ function FeatureCardItem({ card }: Readonly<{ card: FeatureCard }>) {
   const { icon, title, richText } = card;
   return (
     <div className="rounded-3xl bg-accent p-8 md:min-h-75 md:p-8">
-      <span className="mb-9 flex w-fit items-center justify-center rounded-full bg-background p-3 drop-shadow-xl">
-        <SanityIcon icon={icon} />
-      </span>
+      {icon && (
+        <span className="mb-9 flex w-fit items-center justify-center rounded-full bg-background p-3 drop-shadow-xl">
+          <SanityIcon icon={icon} />
+        </span>
+      )}
       <div>
         {title ? (
           <h3 className="mb-2 font-medium text-lg md:text-2xl">{title}</h3>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -2,6 +2,7 @@
 @source "../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";
+@source "../../../sanity-blocks/src/**/*.{ts,tsx}";
 
 @import "tw-animate-css";
 


### PR DESCRIPTION
## What this fixes

Follow-up fixes after the `@workspace/sanity-blocks` extraction (#362 / #403), plus one pre-existing Cache Components bug.

### 1. Page-builder blocks rendered unstyled (the main one)

When the blocks moved into `packages/sanity-blocks`, the web app's Tailwind config was never told to scan that package, so any utility class used only in the moved components was never generated. Feature cards, the CTA, and other blocks lost their grid, card backgrounds, and spacing.

Fix in `packages/ui/src/styles/globals.css` (next to the existing `@source` for the UI package):

```css
@source "../../../sanity-blocks/src/**/*.{ts,tsx}";
```

Verified in the running app: the feature card went from `background: rgba(0,0,0,0)` in a single full-width column to a real 3-column grid with backgrounds.

### 2. Duplicate `id="features"`

The CTA section hardcoded `id="features"`, the same id as the feature-cards section, so any page with both blocks shipped a duplicate id (invalid HTML, breaks `#features` anchors). Changed the CTA to `id="cta"`. Pre-existing, carried over in the move.

### 3. Empty icon badge on feature cards

`SanityIcon` returns `null` for a null icon, but the badge wrapper rendered unconditionally, so every card showed an empty circle (the seed content has no icons). The badge now renders only when an icon is set.

### 4. JSON-LD blocked the route under Cache Components

`<CombinedJsonLd>` in the root layout awaits settings through `sanityFetch`, which reads `draftMode()`, with no Suspense boundary. With `cacheComponents: true` that dynamic access blocks the whole route and aborts the RSC stream (the `controller[kState].transformAlgorithm is not a function` crash). Wrapped it in `<Suspense fallback={null}>`. Pre-existing, from the Cache Components adoption.

## Verification

- `check-types` and `lint` pass; `tsc --noEmit` clean on the touched packages.
- All 32 sitemap URLs return 200 with real content; `/blog` works; a bogus slug 404s.
- Dev-server log stayed clean across the full page sweep (no blocking-route or stream errors), and JSON-LD still emits 5 scripts in the server HTML.

## Notes

- Scoped to 4 files. Unrelated working-tree changes (`schema.json`, `sanity.types.ts`, `turbo.json`) are deliberately left out.
- The `/blog` index page works but isn't in the sitemap (it only lists the homepage plus CMS documents). Not touched here, flagging for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page rendering reliability by loading structured data more safely.
  * CTA links now point to the correct section anchor.
  * Feature cards now only show icons when one is available, preventing empty icon areas.
  * Updated styling coverage so all block components are included consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->