### PR TITLE
Fix : Realtime draft preview by using updateTag in sanity live action

### DIFF
--- a/apps/web/src/lib/sanity-live-action.ts
+++ b/apps/web/src/lib/sanity-live-action.ts
@@ -1,18 +1,17 @@
 "use server";
 
-import { revalidateTag, updateTag } from "next/cache";
-import { draftMode } from "next/headers";
+import { updateTag } from "next/cache";
 import { parseTags } from "next-sanity/live";
 
-// Invalidate cache tags on live events so non-preview visitors see edits without refresh.
+// Runs every time Sanity reports a content change to <SanityLive>.
+// We use `updateTag` (not `revalidateTag`) so the page the user is currently
+// viewing re-renders with the new content right away — `revalidateTag` would
+// only mark the cache stale for the next request, leaving the open page
+// unchanged until a manual reload. This keeps both the Presentation (draft)
+// preview and regular published pages updating live.
 export async function sanityLiveAction(unsafeTags: unknown) {
-  const { isEnabled: isDraftMode } = await draftMode();
   const { tags } = parseTags(unsafeTags);
   for (const tag of tags) {
-    if (isDraftMode) {
-      revalidateTag(tag, "max");
-    } else {
-      updateTag(tag);
-    }
+    updateTag(tag);
   }
 }


### PR DESCRIPTION
## Description

Editing content in Sanity Presentation (draft mode) did not update the open preview in realtime — changes only appeared after a manual reload. The app runs Next.js 16 Cache Components with `next-sanity` v13, where `<SanityLive>` is given a custom `action` (`sanityLiveAction`) to invalidate cache tags on each live event. That action branched on draft mode and called `revalidateTag(tag, "max")` for the draft case, which only marks the cache stale for the _next_ request and never re-renders the page that is already open — so Presentation never updated live.

`sanityLiveAction` now calls `updateTag(tag)` for every changed tag instead of branching between `updateTag` (published) and `revalidateTag` (draft). `updateTag` both expires the cached entry and re-renders the currently open route tree (read-your-own-writes), so a live event refreshes the page in place. This is the only re-render mechanism in this setup, because the custom `action` replaces `<SanityLive>`'s default `refresh()` (which only revalidates client dynamic data, never cached server content) and all data is fetched in server components via `sanityFetch` (no client-side loaders; `VisualEditing` only draws the edit overlay). The draft/published branch was the wrong axis — both cases need the open view refreshed — so this also preserves the published-visitor live-update behavior the previous code added. The now-unused `revalidateTag` and `draftMode` imports are dropped.

**Core file change:** `apps/web/src/lib/sanity-live-action.ts` — replace the draft/published `revalidateTag`/`updateTag` branch with an unconditional `updateTag(tag)` loop, remove unused imports, and update the explanatory comment.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation

## Testing

- [x] `cd apps/web && pnpm check-types` — passes (no unused-import or type errors).
- [x] `pnpm lint` — passes.
- [x] Open the same page in two tabs: one via Sanity Presentation (draft mode) and one as a normal published visitor. Edit/publish a field in Studio and confirm **both** tabs update within a few seconds without a manual reload.
- [x] Confirm draft edits (unpublished) reflect in the Presentation tab specifically — the original regression.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live content updates now refresh consistently for all tagged Sanity content, regardless of preview state.
  * Removed differing behavior between draft and non-draft views so updates appear more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->