### PR TITLE
Added root pnpm type task via turbo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,9 @@ pnpm check-types      # TypeScript type checking
 cd apps/web && pnpm lint
 cd apps/studio && pnpm format
 
-# Sanity type generation (run from apps/studio after schema changes)
-pnpm type             # Extracts schema + generates types
-pnpm extract          # Schema extract only
+# Sanity type generation (run after schema changes)
+pnpm type             # Generates types — works from root (turbo) or apps/studio
+cd apps/studio && pnpm extract   # Schema extract only (studio-scoped)
 ```
 
 ## Monorepo Structure
@@ -56,7 +56,7 @@ packages/
 ### Data Flow: Sanity → Next.js
 
 1. **Schema** block types defined in `packages/sanity-blocks/src/` and re-exported via `@workspace/sanity-blocks`. Studio registers them via `apps/studio/schemaTypes/index.ts`
-2. **Type generation**: `pnpm type` in studio extracts schema → generates TS types at `packages/sanity/src/sanity.types.ts`
+2. **Type generation**: `pnpm type` (from repo root via turbo, or in `apps/studio`) generates TS types at `packages/sanity/src/sanity.types.ts`
 3. **GROQ queries** live in `packages/sanity/src/query.ts` using `defineQuery` from `next-sanity`, with reusable fragments
 4. **Data fetching** uses `sanityFetch` from `packages/sanity/src/live.ts` (wraps `defineLive` for automatic revalidation)
 5. **Client** configured in `packages/sanity/src/client.ts` with stega for visual editing
@@ -74,7 +74,7 @@ To add a new page builder block:
 
 1. Create `packages/sanity-blocks/src/<new-block>/` with `.schema.ts`, `.groq.ts`, and `index.tsx`
 2. Export from `packages/sanity-blocks/src/sanity-blocks.ts` and add to `blockSchemas` so Studio picks it up through `apps/studio/schemaTypes/index.ts` and `definitions/pagebuilder.ts`
-3. Run `pnpm type` in studio to regenerate Sanity types
+3. Run `pnpm type` (from repo root or `apps/studio`) to regenerate Sanity types
 4. Add GROQ fragment in `packages/sanity/src/query.ts` and include in `pageBuilderFragment`
 5. Create styled component in `apps/web/src/components/sections/`
 6. Register in `renderBlockComponent` in `apps/web/src/components/pagebuilder.tsx`

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "turbo run format",
     "format:check": "turbo run format:check",
     "check-types": "turbo run check-types",
+    "type": "turbo run type",
     "test:e2e": "turbo run test:e2e"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,9 @@
     "check-types": {
       "dependsOn": ["transit"]
     },
+    "type": {
+      "cache": false
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Problem / Intent

The Sanity TypeGen command (`type`) lived only in `apps/studio`, so regenerating types required `cd apps/studio && pnpm type` — it did nothing from the repo root. The goal (ROB-1304) is to make `pnpm run type` work from the root by exposing it as a top-level Turborepo task, without changing the existing studio-side behavior.

## Summary

- Added a root `type` script that delegates to Turborepo (`turbo run type`), so `pnpm run type` now regenerates Sanity types from the repo root. The existing `apps/studio` `type` script is unchanged and still works locally.
- Registered `type` as a Turbo task with `cache: false`. Caching is intentionally disabled because the task runs in `apps/studio` but writes its output to `packages/sanity/src/sanity.types.ts` (outside the running package's boundary), which Turbo can't reliably track or restore — caching would risk silent cache-hits that skip regeneration and leave stale/missing types. The command is fast (~1s), so the cost of always running is negligible.
- Updated `CLAUDE.md` so the documented workflow reflects that `pnpm type` runs from the root (or studio), and clarified that `pnpm extract` remains studio-scoped.

## Core file changes

| File           | Change                                                                                                      |
| -------------- | ----------------------------------------------------------------------------------------------------------- |
| `package.json` | Added root script `"type": "turbo run type"` to expose typegen at the workspace root.                       |
| `turbo.json`   | Added `type` task with `cache: false` (output lands outside the running package, so caching is unsafe).     |
| `CLAUDE.md`    | Updated 3 references to note `pnpm type` works from root via turbo; marked `pnpm extract` as studio-scoped. |

## Verification

- [x] `pnpm run type` from the repo root regenerates `packages/sanity/src/sanity.types.ts` (20 queries, 56 schema types)
- [x] `cd apps/studio && pnpm type` still works unchanged
- [x] Delete `packages/sanity/src/sanity.types.ts`, run `pnpm run type` from root → file regenerates byte-identically (verifies the fresh-clone / `cache: false` path)
- [x] Re-running `pnpm run type` shows `cache bypass, force executing` (confirms `cache: false`)
- [x] `pnpm check-types` passes across the monorepo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `type` command for running type generation from the repo root.
  * Expanded guidance so Sanity type generation can be run from either the root or the studio app.

* **Documentation**
  * Updated contributor instructions to clarify the correct commands for type generation and schema extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->