### PR TITLE
Standardise central container across nav, sections and blog

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -141,7 +141,7 @@ function BlogPageContent({
   const { title, description, image, richText } = data ?? {};
 
   return (
-    <div className="container mx-auto my-16 px-4 md:px-6">
+    <div className="container my-16">
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_300px]">
         <main>
           <ArticleJsonLd article={data} />

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -113,7 +113,7 @@ async function DynamicBlogIndex({ searchParams }: BlogPageProps) {
 
   if (errTotalCount || totalCount === null || totalCount === undefined) {
     return (
-      <main className="container mx-auto my-16 px-4 md:px-6">
+      <main className="container my-16">
         <BlogHeader
           description={indexPageData.description}
           title={indexPageData.title}
@@ -158,7 +158,7 @@ async function DynamicBlogIndex({ searchParams }: BlogPageProps) {
 
   if (errBlogs || !blogs) {
     return (
-      <main className="container mx-auto my-16 px-4 md:px-6">
+      <main className="container my-16">
         <BlogHeader
           description={indexPageData.description}
           title={indexPageData.title}
@@ -189,5 +189,5 @@ async function DynamicBlogIndex({ searchParams }: BlogPageProps) {
 }
 
 function BlogIndexFallback() {
-  return <main className="container mx-auto my-16 min-h-[50vh] px-4 md:px-6" />;
+  return <main className="container my-16 min-h-[50vh]" />;
 }

--- a/apps/web/src/components/blog-card.tsx
+++ b/apps/web/src/components/blog-card.tsx
@@ -132,13 +132,11 @@ export function BlogHeader({
   description: string | null;
 }) {
   return (
-    <div className="mx-auto max-w-7xl px-6 lg:px-8">
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="font-bold text-3xl sm:text-4xl">{title}</h1>
-        <p className="mt-4 text-lg text-muted-foreground leading-8">
-          {description}
-        </p>
-      </div>
+    <div className="mx-auto max-w-2xl text-center">
+      <h1 className="font-bold text-3xl sm:text-4xl">{title}</h1>
+      <p className="mt-4 text-lg text-muted-foreground leading-8">
+        {description}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/blog-page-content.tsx
+++ b/apps/web/src/components/blog-page-content.tsx
@@ -56,7 +56,7 @@ export function BlogPageContent({
 
   return (
     <main className="bg-background">
-      <div className="container mx-auto my-16 px-4 md:px-6">
+      <div className="container my-16">
         <BlogHeader description={description} title={title} />
 
         <SearchInput

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -212,8 +212,8 @@ function Footer({ data, settingsData }: FooterProps) {
               </div>
             )}
           </div>
-          <div className="container mt-20 border-t pt-8">
-            <div className="flex flex-col justify-between gap-4 text-center font-normal text-muted-foreground text-sm lg:flex-row lg:items-center lg:text-left">
+          <div className="container mt-20">
+            <div className="flex flex-col justify-between gap-4 border-t pt-8 text-center font-normal text-muted-foreground text-sm lg:flex-row lg:items-center lg:text-left">
               <p>
                 © {year} {siteTitle}. All rights reserved.
               </p>

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -109,7 +109,7 @@ function SocialLinks({ data }: SocialLinksProps) {
 export function FooterSkeleton() {
   return (
     <footer className="mt-16 pb-8">
-      <section className="container mx-auto px-4 md:px-6">
+      <section className="container">
         <div className="h-[500px] lg:h-auto">
           <div className="flex flex-col items-center justify-between gap-10 text-center lg:flex-row lg:text-left">
             <div className="flex w-full max-w-96 shrink flex-col items-center justify-between gap-6 lg:items-start">
@@ -164,9 +164,9 @@ function Footer({ data, settingsData }: FooterProps) {
 
   return (
     <footer className="mt-20 pb-8">
-      <section className="container mx-auto">
+      <section>
         <div className="h-[500px] lg:h-auto">
-          <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-10 px-4 text-center md:px-6 lg:flex-row lg:text-left">
+          <div className="container flex flex-col items-center justify-between gap-10 text-center lg:flex-row lg:text-left">
             <div className="flex w-full max-w-96 shrink flex-col items-center justify-between gap-6 md:gap-8 lg:items-start">
               <div>
                 <span className="flex items-center justify-center gap-4 lg:justify-start">
@@ -212,8 +212,8 @@ function Footer({ data, settingsData }: FooterProps) {
               </div>
             )}
           </div>
-          <div className="mt-20 border-t pt-8">
-            <div className="mx-auto flex max-w-7xl flex-col justify-between gap-4 px-4 text-center font-normal text-muted-foreground text-sm md:px-6 lg:flex-row lg:items-center lg:text-left">
+          <div className="container mt-20 border-t pt-8">
+            <div className="flex flex-col justify-between gap-4 text-center font-normal text-muted-foreground text-sm lg:flex-row lg:items-center lg:text-left">
               <p>
                 © {year} {siteTitle}. All rights reserved.
               </p>

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -95,7 +95,7 @@ function DesktopColumnLink({
 export function NavbarSkeleton() {
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background/80 backdrop-blur-sm">
-      <div className="container mx-auto px-4">
+      <div className="container">
         <div className="flex h-16 items-center justify-between">
           {/* Logo skeleton - matches Logo component dimensions: width={120} height={40} */}
           {/* <div className="flex items-center">
@@ -165,7 +165,7 @@ export function Navbar({
 
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-background/80 backdrop-blur-sm">
-      <div className="container mx-auto px-4">
+      <div className="container">
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <div className="flex h-10 w-40 items-center">

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -188,6 +188,8 @@ export function PageBuilder({
   }
 
   return (
+    // Full-bleed by design: each block owns its own `container` rail (see
+    // renderBlockComponent). A block that omits one renders edge-to-edge.
     <main
       className="my-16 flex flex-col gap-16"
       data-sanity={containerDataAttribute}

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -189,7 +189,7 @@ export function PageBuilder({
 
   return (
     <main
-      className="mx-auto my-16 flex max-w-7xl flex-col gap-16"
+      className="my-16 flex flex-col gap-16"
       data-sanity={containerDataAttribute}
     >
       {blocks.map(renderBlock)}

--- a/packages/sanity-blocks/src/cta/index.tsx
+++ b/packages/sanity-blocks/src/cta/index.tsx
@@ -19,7 +19,7 @@ export function CTABlock({
 }: Readonly<CtaBlockProps>) {
   return (
     <section className="my-6 md:my-16" id="cta">
-      <div className="container mx-auto px-4 md:px-8">
+      <div className="container">
         <div className="rounded-3xl bg-muted px-4 py-16">
           <div className="mx-auto max-w-3xl space-y-8 text-center">
             {eyebrow && (

--- a/packages/sanity-blocks/src/faq-accordion/index.tsx
+++ b/packages/sanity-blocks/src/faq-accordion/index.tsx
@@ -43,7 +43,7 @@ export function FaqAccordion({
 
   return (
     <section className="my-8" id="faq">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
             {eyebrow && <Badge variant="secondary">{eyebrow}</Badge>}

--- a/packages/sanity-blocks/src/feature-cards-icon/index.tsx
+++ b/packages/sanity-blocks/src/feature-cards-icon/index.tsx
@@ -47,7 +47,7 @@ export function FeatureCardsWithIcon({
 }: Readonly<FeatureCardsIconProps>) {
   return (
     <section className="my-6 md:my-16" id="features">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
             {eyebrow && <Badge variant="secondary">{eyebrow}</Badge>}

--- a/packages/sanity-blocks/src/hero/index.tsx
+++ b/packages/sanity-blocks/src/hero/index.tsx
@@ -23,7 +23,7 @@ export function HeroBlock({
 }: Readonly<HeroBlockProps>) {
   return (
     <section className="mt-4 md:my-16" id="hero">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <div className="grid items-center gap-8 lg:grid-cols-2">
           <div className="grid h-full grid-rows-[auto_1fr_auto] items-center justify-items-center gap-4 text-center lg:items-start lg:justify-items-start lg:text-left">
             {badge && <Badge variant="secondary">{badge}</Badge>}

--- a/packages/sanity-blocks/src/image-link-cards/index.tsx
+++ b/packages/sanity-blocks/src/image-link-cards/index.tsx
@@ -80,7 +80,7 @@ export function ImageLinkCards({
 }: Readonly<ImageLinkCardsProps>) {
   return (
     <section className="my-16" id="image-link-cards">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
             {eyebrow && <Badge variant="secondary">{eyebrow}</Badge>}

--- a/packages/sanity-blocks/src/rich-text-block/index.tsx
+++ b/packages/sanity-blocks/src/rich-text-block/index.tsx
@@ -15,7 +15,7 @@ export function RichTextBlock({
 }: Readonly<RichTextBlockProps>) {
   return (
     <section className="my-6 md:my-16">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <div className="flex w-full flex-col items-center">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
             {eyebrow && <Badge variant="secondary">{eyebrow}</Badge>}

--- a/packages/sanity-blocks/src/subscribe-newsletter/index.tsx
+++ b/packages/sanity-blocks/src/subscribe-newsletter/index.tsx
@@ -56,44 +56,46 @@ export function SubscribeNewsletter({
   onSubmit,
 }: Readonly<SubscribeNewsletterProps>) {
   return (
-    <section className="px-4 py-8 sm:py-12 md:py-16" id="subscribe">
-      <div className="container relative mx-auto overflow-hidden rounded-3xl bg-gray-50 px-4 py-8 sm:py-16 md:px-8 md:py-24 lg:py-32 dark:bg-zinc-900">
-        <div className="relative z-10 mx-auto text-center">
-          {title && (
-            <h2 className="mb-4 text-balance font-semibold text-gray-900 text-xl sm:text-3xl md:text-5xl dark:text-neutral-300">
-              {title}
-            </h2>
-          )}
-          {subTitle && (
-            <RichText
-              className="mb-6 text-balance text-gray-600 text-sm sm:mb-8 sm:text-base dark:text-neutral-300"
-              richText={subTitle}
-            />
-          )}
-          <form
-            action={action}
-            className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-2"
-            method={method ?? "post"}
-            onSubmit={onSubmit}
-          >
-            <div className="flex items-center justify-between rounded-xl border bg-white p-2 pl-4 drop-shadow-lg md:w-96 dark:bg-zinc-200">
-              <input
-                aria-label="Email address"
-                className="w-full rounded-e-none border-e-0 bg-transparent outline-none focus-visible:ring-0 dark:text-zinc-900 dark:placeholder:text-zinc-900"
-                name="email"
-                placeholder="Enter your email address"
-                required
-                type="email"
+    <section className="py-8 sm:py-12 md:py-16" id="subscribe">
+      <div className="container">
+        <div className="relative overflow-hidden rounded-3xl bg-gray-50 px-4 py-8 sm:py-16 md:px-8 md:py-24 lg:py-32 dark:bg-zinc-900">
+          <div className="relative z-10 mx-auto text-center">
+            {title && (
+              <h2 className="mb-4 text-balance font-semibold text-gray-900 text-xl sm:text-3xl md:text-5xl dark:text-neutral-300">
+                {title}
+              </h2>
+            )}
+            {subTitle && (
+              <RichText
+                className="mb-6 text-balance text-gray-600 text-sm sm:mb-8 sm:text-base dark:text-neutral-300"
+                richText={subTitle}
               />
-              <SubscribeNewsletterButton />
-            </div>
-          </form>
-          {helperText && (
-            <RichText
-              className="mt-3 text-gray-800 text-sm opacity-80 sm:mt-4 dark:text-neutral-300"
-              richText={helperText}
-            />
-          )}
+            )}
+            <form
+              action={action}
+              className="flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-2"
+              method={method ?? "post"}
+              onSubmit={onSubmit}
+            >
+              <div className="flex items-center justify-between rounded-xl border bg-white p-2 pl-4 drop-shadow-lg md:w-96 dark:bg-zinc-200">
+                <input
+                  aria-label="Email address"
+                  className="w-full rounded-e-none border-e-0 bg-transparent outline-none focus-visible:ring-0 dark:text-zinc-900 dark:placeholder:text-zinc-900"
+                  name="email"
+                  placeholder="Enter your email address"
+                  required
+                  type="email"
+                />
+                <SubscribeNewsletterButton />
+              </div>
+            </form>
+            {helperText && (
+              <RichText
+                className="mt-3 text-gray-800 text-sm opacity-80 sm:mt-4 dark:text-neutral-300"
+                richText={helperText}
+              />
+            )}
+          </div>
         </div>
       </div>
     </section>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -118,6 +118,16 @@
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
+@utility container {
+  margin-inline: auto;
+  width: 100%;
+  max-width: 80rem; /* max-w-7xl */
+  padding-inline: 1rem; /* px-4 */
+  @media (width >= 48rem) {
+    padding-inline: 1.5rem; /* md:px-6 */
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -118,14 +118,17 @@
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
+@media (width >= 48rem) {
+  :root {
+    --container-px: 1.5rem; /* md:px-6 */
+  }
+}
+
 @utility container {
   margin-inline: auto;
   width: 100%;
   max-width: 80rem; /* max-w-7xl */
-  padding-inline: 1rem; /* px-4 */
-  @media (width >= 48rem) {
-    padding-inline: 1.5rem; /* md:px-6 */
-  }
+  padding-inline: var(--container-px, 1rem); /* px-4, md:px-6 from breakpoint */
 }
 
 @layer base {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -118,17 +118,13 @@
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
-@media (width >= 48rem) {
-  :root {
-    --container-px: 1.5rem; /* md:px-6 */
-  }
-}
-
+/* Overrides Tailwind's built-in `container`. Both rules are emitted; this
+ * `max-width` wins by source order (equal specificity), not by replacement.
+ * Correct on the pinned Tailwind version — if an upgrade reorders emission, the
+ * built-in's larger 2xl max-width could reassert. Revisit (or move to a distinct
+ * utility name) when upgrading Tailwind. */
 @utility container {
-  margin-inline: auto;
-  width: 100%;
-  max-width: 80rem; /* max-w-7xl */
-  padding-inline: var(--container-px, 1rem); /* px-4, md:px-6 from breakpoint */
+  @apply mx-auto w-full max-w-7xl px-4 md:px-6;
 }
 
 @layer base {


### PR DESCRIPTION
## Problem / Intent

The site had no shared definition for its central content container. Two different max-width systems were in use — a fixed `max-w-7xl` on the page-builder `<main>` and footer rows, versus Tailwind's responsive `container` on the navbar, every page-builder block, and the blog pages — alongside three different gutter recipes (`px-4`, `px-4 md:px-6`, `px-4 md:px-8`). The page-builder also double-wrapped content (a `max-w-7xl` `<main>` around blocks that each re-applied their own `container` rail), so gutters didn't line up between the nav, content, and footer. This change (ROB-2104) establishes one shared rail and applies it everywhere so all three align.

## Summary

- Overrode Tailwind's built-in `container` utility to a single fixed rail (`max-width: 80rem`, `margin-inline: auto`, `px-4` / `md:px-6` gutters) in the shared theme, making it the one source of truth that every `container` usage inherits site-wide.
- Removed the page-builder double-rail: the `<main>` wrapper no longer constrains width, so each block owns its own `container` rail (also enabling full-bleed section backgrounds).
- Normalised every rail call site to bare `container`, shedding the now-redundant `mx-auto` / `px-*` / `max-w-7xl` classes across the navbar, footer, all page-builder blocks, and the blog index/post pages.
- Fixed two stray rails on the blog: `blog-page-content.tsx` now uses the standard rail, and `BlogHeader` lost its redundant nested `max-w-7xl px-6 lg:px-8` (it always renders inside a page `container`).
- Special-cased `subscribe-newsletter`: its styled card is now wrapped in a `container` div rather than doubling as the rail, avoiding a gutter/card-padding collision while preserving the card's full-bleed background.

## Core file changes

| File | Change |
| --- | --- |
| `packages/ui/src/styles/globals.css` | Adds `@utility container` overriding Tailwind's default — fixed 80rem width, centered, `px-4` / `md:px-6` gutters. The single rail definition. |
| `apps/web/src/components/pagebuilder.tsx` | Drops `mx-auto max-w-7xl` from `<main>` (now `my-16 flex flex-col gap-16`); blocks own their own rail. |
| `apps/web/src/components/navbar.tsx` | Header + skeleton rails simplified from `container mx-auto px-4` to `container`. |
| `apps/web/src/components/footer.tsx` | Rails moved onto the content row and bottom-bar divider as bare `container`; removed `max-w-7xl` rows and the outer `container mx-auto`. |
| `apps/web/src/components/blog-card.tsx` | `BlogHeader` no longer wraps content in a redundant `max-w-7xl px-6 lg:px-8` rail. |
| `apps/web/src/components/blog-page-content.tsx` | Rail normalised to `container my-16`. |
| `apps/web/src/app/blog/page.tsx`, `apps/web/src/app/blog/[slug]/page.tsx` | Page rails normalised to `container my-16` (drop `mx-auto px-4 md:px-6`). |
| `packages/sanity-blocks/src/{cta,feature-cards-icon,rich-text-block,hero,image-link-cards,faq-accordion}/index.tsx` | Inner rail `container mx-auto px-…` → `container` in all six standard blocks. |
| `packages/sanity-blocks/src/subscribe-newsletter/index.tsx` | Card wrapped in a `container` div; outer `px-4` dropped; card keeps its own background and interior padding. |

## Preview

<img width="1862" height="925" alt="image" src="https://github.com/user-attachments/assets/0b6769a2-eace-48bd-8fd3-f6ce50d77222" />

## Verification

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build:web`
- [x] Load `/`, a content page, `/blog`, and `/blog/<slug>`; confirm the navbar, section content, and footer share the same left/right gutter at mobile, `md`, and wide (>80rem) widths.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized layout container usage across blog pages, navigation, footer, and reusable content blocks by switching many wrappers to a consistent `container`-based approach.
  * Refined newsletter section spacing by restructuring its outer wrappers and adjusting section padding behavior.
  * Updated global styling to override Tailwind’s `container` utility, centralizing site-wide centering, max width, and responsive horizontal padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->