### PR TITLE
refactor: co-locate page-builder surfaces and adopt @portabletext/markdown

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -7,10 +7,12 @@ import {
   sanityFetchStaticParams,
 } from "@workspace/sanity/live";
 import { querySlugPageData, querySlugPagePaths } from "@workspace/sanity/query";
+import type { Metadata } from "next";
 import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
+import { PageBuilderJsonLd } from "@/components/page-builder-json-ld";
 import { PageBuilder } from "@/components/pagebuilder";
 import { getSEOMetadata } from "@/lib/seo";
 
@@ -49,7 +51,7 @@ export async function generateMetadata({
   params,
 }: {
   params: Promise<SlugParams>;
-}) {
+}): Promise<Metadata> {
   const [{ slug }, { perspective }] = await Promise.all([
     params,
     getDynamicFetchOptions(),
@@ -131,15 +133,22 @@ function SlugPageContent({
 }) {
   const { title, pageBuilder, _id, _type } = pageData ?? {};
 
-  return !Array.isArray(pageBuilder) || pageBuilder?.length === 0 ? (
-    <div className="flex min-h-[50vh] flex-col items-center justify-center p-4 text-center">
-      <h1 className="mb-4 font-semibold text-2xl capitalize">{title}</h1>
-      <p className="mb-6 text-muted-foreground">
-        This page has no content blocks yet.
-      </p>
-    </div>
-  ) : (
-    <PageBuilder id={_id} pageBuilder={pageBuilder} type={_type} />
+  if (!Array.isArray(pageBuilder) || pageBuilder?.length === 0) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center p-4 text-center">
+        <h1 className="mb-4 font-semibold text-2xl capitalize">{title}</h1>
+        <p className="mb-6 text-muted-foreground">
+          This page has no content blocks yet.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <PageBuilderJsonLd pageBuilder={pageBuilder} />
+      <PageBuilder id={_id} pageBuilder={pageBuilder} type={_type} />
+    </>
   );
 }
 

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   sanityFetchStaticParams,
 } from "@workspace/sanity/live";
 import { queryBlogPaths, queryBlogSlugPageData } from "@workspace/sanity/query";
+import type { Metadata } from "next";
 import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
@@ -58,7 +59,7 @@ export async function generateMetadata({
   params,
 }: {
   params: Promise<BlogParams>;
-}) {
+}): Promise<Metadata> {
   const [{ slug }, { perspective }] = await Promise.all([
     params,
     getDynamicFetchOptions(),

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -9,11 +9,13 @@ import {
   queryBlogIndexPageBlogsCount,
   queryBlogIndexPageData,
 } from "@workspace/sanity/query";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
 import { BlogHeader } from "@/components/blog-card";
 import { BlogPageContent } from "@/components/blog-page-content";
+import { PageBuilderJsonLd } from "@/components/page-builder-json-ld";
 import { PageBuilder } from "@/components/pagebuilder";
 import { getSEOMetadata } from "@/lib/seo";
 import {
@@ -64,7 +66,7 @@ async function fetchBlogIndexPageBlogsCount({
   return res.data;
 }
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
   const { perspective } = await getDynamicFetchOptions();
   const { data: result } = await sanityFetchMetadata({
     query: queryBlogIndexPageData,
@@ -124,11 +126,14 @@ async function DynamicBlogIndex({ searchParams }: BlogPageProps) {
           </p>
         </div>
         {indexPageData.pageBuilder && indexPageData.pageBuilder.length > 0 && (
-          <PageBuilder
-            id={indexPageData._id}
-            pageBuilder={indexPageData.pageBuilder}
-            type={indexPageData._type}
-          />
+          <>
+            <PageBuilderJsonLd pageBuilder={indexPageData.pageBuilder} />
+            <PageBuilder
+              id={indexPageData._id}
+              pageBuilder={indexPageData.pageBuilder}
+              type={indexPageData._type}
+            />
+          </>
         )}
       </main>
     );
@@ -169,22 +174,28 @@ async function DynamicBlogIndex({ searchParams }: BlogPageProps) {
           </p>
         </div>
         {indexPageData.pageBuilder && indexPageData.pageBuilder.length > 0 && (
-          <PageBuilder
-            id={indexPageData._id}
-            pageBuilder={indexPageData.pageBuilder}
-            type={indexPageData._type}
-          />
+          <>
+            <PageBuilderJsonLd pageBuilder={indexPageData.pageBuilder} />
+            <PageBuilder
+              id={indexPageData._id}
+              pageBuilder={indexPageData.pageBuilder}
+              type={indexPageData._type}
+            />
+          </>
         )}
       </main>
     );
   }
 
   return (
-    <BlogPageContent
-      blogs={blogs}
-      indexPageData={indexPageData}
-      paginationMetadata={paginationMetadata}
-    />
+    <>
+      <PageBuilderJsonLd pageBuilder={indexPageData.pageBuilder} />
+      <BlogPageContent
+        blogs={blogs}
+        indexPageData={indexPageData}
+        paginationMetadata={paginationMetadata}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,118 @@
+import { Logger } from "@workspace/logger";
+import { sanityFetch } from "@workspace/sanity/live";
+import {
+  queryAllBlogDataForSearch,
+  queryGlobalSeoSettings,
+  querySlugPagePaths,
+} from "@workspace/sanity/query";
+
+const logger = new Logger("LlmsTxt");
+
+const PUBLISHED = { perspective: "published", stega: false } as const;
+
+const HEADERS = {
+  "content-type": "text/plain; charset=utf-8",
+  "cache-control": "public, s-maxage=3600, stale-while-revalidate=86400",
+} as const;
+
+async function fetchSettings() {
+  "use cache";
+  const { data } = await sanityFetch({
+    query: queryGlobalSeoSettings,
+    ...PUBLISHED,
+  });
+  return data;
+}
+
+async function fetchSlugs() {
+  "use cache";
+  const { data } = await sanityFetch({
+    query: querySlugPagePaths,
+    ...PUBLISHED,
+  });
+  return data;
+}
+
+async function fetchPosts() {
+  "use cache";
+  const { data } = await sanityFetch({
+    query: queryAllBlogDataForSearch,
+    ...PUBLISHED,
+  });
+  return data;
+}
+
+function slugToTitle(slug: string): string {
+  return slug
+    .replace(/^\//, "")
+    .split("/")
+    .filter(Boolean)
+    .map((segment) =>
+      segment
+        .split("-")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(" ")
+    )
+    .join(" / ");
+}
+
+export async function GET(): Promise<Response> {
+  const [settingsResult, slugsResult, postsResult] = await Promise.allSettled([
+    fetchSettings(),
+    fetchSlugs(),
+    fetchPosts(),
+  ]);
+
+  if (settingsResult.status === "rejected") {
+    logger.error("llms.txt: settings fetch failed", settingsResult.reason);
+  }
+  if (slugsResult.status === "rejected") {
+    logger.error("llms.txt: page slugs fetch failed", slugsResult.reason);
+  }
+  if (postsResult.status === "rejected") {
+    logger.error("llms.txt: blog posts fetch failed", postsResult.reason);
+  }
+
+  const settings =
+    settingsResult.status === "fulfilled" ? settingsResult.value : null;
+  const slugs =
+    slugsResult.status === "fulfilled" ? (slugsResult.value ?? []) : [];
+  const posts =
+    postsResult.status === "fulfilled" ? (postsResult.value ?? []) : [];
+
+  const siteTitle = settings?.siteTitle ?? "Site";
+  const siteDescription = settings?.siteDescription ?? "";
+
+  const pageLines = [
+    "- [Home](/index.md)",
+    ...slugs
+      .filter((s): s is string => Boolean(s))
+      .map((slug) => {
+        const path = slug.startsWith("/") ? slug : `/${slug}`;
+        return `- [${slugToTitle(path)}](${path}.md)`;
+      }),
+  ];
+
+  const sortedPosts = [...posts].sort((a, b) =>
+    (a.orderRank ?? "").localeCompare(b.orderRank ?? "")
+  );
+
+  const blogLines = sortedPosts.flatMap((post) =>
+    post.slug
+      ? [`- [${post.title ?? slugToTitle(post.slug)}](${post.slug}.md)`]
+      : []
+  );
+
+  const body = [
+    `# ${siteTitle}`,
+    ...(siteDescription ? [`> ${siteDescription}`] : []),
+    "",
+    "## Pages",
+    ...pageLines,
+    "",
+    "## Blog",
+    ...blogLines,
+  ].join("\n");
+
+  return new Response(`${body}\n`, { headers: HEADERS });
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,13 +5,15 @@ import {
   sanityFetchMetadata,
 } from "@workspace/sanity/live";
 import { queryHomePageData } from "@workspace/sanity/query";
+import type { Metadata } from "next";
 import { draftMode } from "next/headers";
 import { Suspense } from "react";
 
+import { PageBuilderJsonLd } from "@/components/page-builder-json-ld";
 import { PageBuilder } from "@/components/pagebuilder";
 import { getSEOMetadata } from "@/lib/seo";
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
   const { perspective } = await getDynamicFetchOptions();
   const { data: homePageData } = await sanityFetchMetadata({
     query: queryHomePageData,
@@ -57,7 +59,12 @@ async function CachedHome({ perspective, stega }: DynamicFetchOptions) {
 
   const { _id, _type, pageBuilder } = homePageData ?? {};
 
-  return <PageBuilder id={_id} pageBuilder={pageBuilder ?? []} type={_type} />;
+  return (
+    <>
+      <PageBuilderJsonLd pageBuilder={pageBuilder} />
+      <PageBuilder id={_id} pageBuilder={pageBuilder ?? []} type={_type} />
+    </>
+  );
 }
 
 function HomeFallback() {

--- a/apps/web/src/components/json-ld.tsx
+++ b/apps/web/src/components/json-ld.tsx
@@ -5,14 +5,11 @@ import type {
 } from "@workspace/sanity/types";
 import { stegaClean } from "next-sanity";
 import type {
-  Answer,
   Article,
   ContactPoint,
-  FAQPage,
   ImageObject,
   Organization,
   Person,
-  Question,
   WebPage,
   WebSite,
   WithContext,
@@ -20,48 +17,6 @@ import type {
 
 import { getJsonLdSettings } from "@/lib/json-ld-data";
 import { getBaseUrl } from "@/utils";
-
-type RichTextChild = {
-  _type: string;
-  text?: string;
-  marks?: string[];
-  _key: string;
-};
-
-type RichTextBlock = {
-  _type: string;
-  children?: RichTextChild[];
-  style?: string;
-  _key: string;
-};
-
-// Flexible FAQ type that can accept different rich text structures
-type FlexibleFaq = {
-  _id: string;
-  title: string;
-  richText?: RichTextBlock[] | null;
-};
-
-// Utility function to safely extract plain text from rich text blocks
-function extractPlainTextFromRichText(
-  richText: RichTextBlock[] | null | undefined
-): string {
-  if (!Array.isArray(richText)) {
-    return "";
-  }
-
-  return richText
-    .filter((block) => block._type === "block" && Array.isArray(block.children))
-    .map(
-      (block) =>
-        block.children
-          ?.filter((child) => child._type === "span" && Boolean(child.text))
-          .map((child) => child.text)
-          .join("") ?? ""
-    )
-    .join(" ")
-    .trim();
-}
 
 // Escape <, >, & to \uXXXX so a "</script>" in any CMS field can't break out of
 // the tag. JSON-LD is parsed as data (not executed), so escaping < is what
@@ -83,43 +38,6 @@ export function JsonLdScript<T>({ data, id }: { data: T; id: string }) {
       type="application/ld+json"
     />
   );
-}
-
-// FAQ JSON-LD Component
-type FaqJsonLdProps = {
-  faqs: FlexibleFaq[];
-  id?: string;
-};
-
-export function FaqJsonLd({ faqs, id = "faq-json-ld" }: FaqJsonLdProps) {
-  if (!faqs?.length) {
-    return null;
-  }
-
-  const validFaqs = stegaClean(
-    faqs.filter((faq) => faq?.title && faq?.richText)
-  );
-
-  if (!validFaqs.length) {
-    return null;
-  }
-
-  const faqJsonLd: WithContext<FAQPage> = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: validFaqs.map(
-      (faq): Question => ({
-        "@type": "Question",
-        name: faq.title,
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: extractPlainTextFromRichText(faq.richText),
-        } as Answer,
-      })
-    ),
-  };
-
-  return <JsonLdScript data={faqJsonLd} id={id} />;
 }
 
 const IMAGE_SIZE_WIDTH = 1920;
@@ -277,7 +195,6 @@ export function WebSiteJsonLd({ settings }: WebSiteJsonLdProps) {
 type CombinedJsonLdProps = {
   settings?: QuerySettingsDataResult;
   article?: QueryBlogSlugPageDataResult;
-  faqs?: FlexibleFaq[];
   includeWebsite?: boolean;
   includeOrganization?: boolean;
 };

--- a/apps/web/src/components/page-builder-json-ld.tsx
+++ b/apps/web/src/components/page-builder-json-ld.tsx
@@ -1,0 +1,32 @@
+import { faqAccordionToJsonLd } from "@workspace/sanity-blocks/faq-accordion/json-ld";
+import { stegaClean } from "next-sanity";
+
+import { JsonLdScript } from "@/components/json-ld";
+import type { PageBuilderBlock, PagebuilderType } from "@/types";
+
+export function PageBuilderJsonLd({
+  pageBuilder,
+}: {
+  pageBuilder?: PageBuilderBlock[] | null;
+}) {
+  if (!pageBuilder?.length) return null;
+
+  return (
+    <>
+      {pageBuilder.map((block) => {
+        if (!block || block._type !== "faqAccordion") return null;
+        const data = faqAccordionToJsonLd(
+          stegaClean(block as PagebuilderType<"faqAccordion">)
+        );
+        if (!data) return null;
+        return (
+          <JsonLdScript
+            data={data}
+            id={`faq-json-ld-${block._key}`}
+            key={`faq-json-ld-${block._key}`}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -11,7 +11,6 @@ import { RichTextBlock } from "@workspace/sanity-blocks/rich-text-block/index";
 import { SubscribeNewsletter } from "@workspace/sanity-blocks/subscribe-newsletter/index";
 import { createDataAttribute } from "next-sanity";
 
-import { FaqJsonLd } from "@/components/json-ld";
 import type { PageBuilderBlock, PagebuilderType } from "@/types";
 
 export type PageBuilderProps = {
@@ -35,15 +34,8 @@ function renderBlockComponent(block: PageBuilderBlock) {
   switch (block?._type) {
     case "cta":
       return <CTABlock {...(block as PagebuilderType<"cta">)} />;
-    case "faqAccordion": {
-      const props = block as PagebuilderType<"faqAccordion">;
-      return (
-        <>
-          <FaqJsonLd faqs={props.faqs ?? []} id={`faq-json-ld-${props._key}`} />
-          <FaqAccordion {...props} />
-        </>
-      );
-    }
+    case "faqAccordion":
+      return <FaqAccordion {...(block as PagebuilderType<"faqAccordion">)} />;
     case "hero":
       return <HeroBlock {...(block as PagebuilderType<"hero">)} />;
     case "featureCardsIcon":

--- a/apps/web/src/lib/markdown-path.ts
+++ b/apps/web/src/lib/markdown-path.ts
@@ -7,20 +7,14 @@ export const MARKDOWN_MEDIA_TYPE = "text/markdown";
 
 /** Canonicalizes a path: strips `.md` and trailing slash, maps `/index` → `/`. */
 export function normalizeMarkdownPath(raw: string): string {
-  let path = raw.trim();
-  if (!path.startsWith("/")) {
-    path = `/${path}`;
-  }
-  if (path.endsWith(".md")) {
-    path = path.slice(0, -3);
-  }
-  if (path.length > 1 && path.endsWith("/")) {
-    path = path.slice(0, -1);
-  }
-  if (path === "/index") {
-    path = "/";
-  }
-  return path;
+  const trimmed = raw.trim();
+  const slashed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const withoutMd = slashed.endsWith(".md") ? slashed.slice(0, -3) : slashed;
+  const withoutTrailing =
+    withoutMd.length > 1 && withoutMd.endsWith("/")
+      ? withoutMd.slice(0, -1)
+      : withoutMd;
+  return withoutTrailing === "/index" ? "/" : withoutTrailing;
 }
 
 /**
@@ -52,14 +46,12 @@ function parseAccept(accept: string): Array<{ type: string; q: number }> {
  * type's q). So `text/markdown` wins; `;q=0` and HTML-preferred lists do not.
  */
 export function prefersMarkdown(accept: string): boolean {
-  let markdownQ = 0;
-  let otherQ = 0;
-  for (const { type, q } of parseAccept(accept)) {
-    if (type === MARKDOWN_MEDIA_TYPE) {
-      markdownQ = Math.max(markdownQ, q);
-    } else {
-      otherQ = Math.max(otherQ, q);
-    }
-  }
+  const entries = parseAccept(accept);
+  const markdownQ = entries
+    .filter(({ type }) => type === MARKDOWN_MEDIA_TYPE)
+    .reduce((max, { q }) => Math.max(max, q), 0);
+  const otherQ = entries
+    .filter(({ type }) => type !== MARKDOWN_MEDIA_TYPE)
+    .reduce((max, { q }) => Math.max(max, q), 0);
   return markdownQ > 0 && markdownQ >= otherQ;
 }

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -143,6 +143,12 @@ export async function getSEOMetadata(
       ? defaultTitle
       : `${defaultTitle} | ${siteConfig.title}`;
 
+  const markdownUrl =
+    slug && slug !== "/" ? `${pageUrl}.md` : `${baseUrl}/index.md`;
+  const markdownTypes = seoNoIndex
+    ? undefined
+    : { "text/markdown": [{ url: markdownUrl, title: fullTitle }] };
+
   // Build default metadata object
   const defaultMetadata: Metadata = {
     title: fullTitle,
@@ -164,6 +170,7 @@ export async function getSEOMetadata(
     },
     alternates: {
       canonical: pageUrl,
+      types: markdownTypes,
     },
     openGraph: {
       type: pageType ?? "website",
@@ -184,8 +191,10 @@ export async function getSEOMetadata(
   };
 
   // Override any defaults with page-specific metadata
+  const { alternates: alternatesOverride, ...restOverrides } = pageOverrides;
   return {
     ...defaultMetadata,
-    ...pageOverrides,
+    ...restOverrides,
+    alternates: { ...defaultMetadata.alternates, ...alternatesOverride },
   };
 }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -46,5 +46,7 @@ export function proxy(request: NextRequest): NextResponse {
 }
 
 export const config = {
-  matcher: ["/((?!api/|_next/|favicon.ico|robots.txt|sitemap.xml).*)"],
+  matcher: [
+    "/((?!api/|_next/|favicon.ico|robots.txt|sitemap.xml|llms\\.txt).*)",
+  ],
 };

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,0 +1,30 @@
+# Turbo Start Sanity
+
+A Sanity-driven Next.js starter built around a **page builder**: a page is an ordered array of typed content blocks. This glossary pins the language for how those blocks are modeled and how their data is rendered for different audiences.
+
+## Language
+
+**Page-builder block**:
+One typed content unit in a page's `pageBuilder` array (e.g. `hero`, `faqAccordion`, `cta`). Authored in Sanity, rendered by the frontend.
+_Avoid_: section, component, widget, module
+
+**Surface**:
+One serialization of a page-builder block's data for a specific audience. Three exist today: **HTML** (rendered React, for humans), **JSON-LD** (schema.org structured data embedded in the HTML page, for search crawlers), and **Markdown** (plain-text serialization at a separate URL, for LLMs/agents). One block's data, many surfaces. HTML and Markdown apply to every block; JSON-LD is **opportunistic** — only blocks that map to a real schema.org type carry it.
+_Avoid_: format, representation, output — reserve "surface" for the audience-specific cut.
+
+**Markdown twin**:
+The Markdown **surface** of a whole page, served at a parallel `.md` URL (or via `Accept: text/markdown`). Kept `noindex` so it never competes with the canonical HTML in search — it is the AEO channel, advertised via a per-page `rel="alternate"` link and a site-level `/llms.txt` index.
+_Avoid_: markdown page, .md route — those name the mechanism, not the concept.
+
+## Flagged ambiguities
+
+**SEO vs AEO** — kept distinct because they use opposite mechanisms:
+- **SEO** (search-engine optimization): ranking the *indexed HTML page* in Google. Mechanism here is semantic HTML + JSON-LD emitted **into** the page. The FAQ block already does this (native `<details>` + `FAQPage` JSON-LD).
+- **AEO** (answer-engine optimization): being cleanly consumed by LLMs / answer engines (ChatGPT, Perplexity, Google AI). Mechanism here is the **Markdown** surface, served at `.md` or `Accept: text/markdown`.
+- A Markdown surface that is `noindex` contributes **nothing** to SEO. "Markdown for SEO" is a category error — Markdown serves AEO.
+_Avoid_: using "SEO" to mean "machine-readable" in general.
+
+## Example
+
+> **Dev:** "Let's add JSON-LD to the hero block's Markdown surface for SEO."
+> **Domain expert:** "Three things are crossed. JSON-LD and Markdown are different *surfaces* — JSON-LD goes inside the HTML page, Markdown is the separate `.md` twin. JSON-LD serves SEO; the Markdown twin serves AEO and is noindexed. And a hero has no schema.org type, so it has no JSON-LD surface at all — only HTML and Markdown."

--- a/packages/sanity-blocks/package.json
+++ b/packages/sanity-blocks/package.json
@@ -19,6 +19,7 @@
     "sanity": "catalog:"
   },
   "dependencies": {
+    "@portabletext/markdown": "^1.4.2",
     "@sanity/icons": "^3.7.4",
     "@workspace/env": "workspace:*",
     "@workspace/logger": "workspace:*",
@@ -28,6 +29,7 @@
     "next-sanity": "^12.1.1",
     "sanity": "catalog:",
     "sanity-image": "^1.1.0",
+    "schema-dts": "^1.1.5",
     "slugify": "^1.6.8"
   },
   "devDependencies": {
@@ -43,6 +45,7 @@
   "exports": {
     ".": "./src/sanity-blocks.ts",
     "./*/index": "./src/*/index.tsx",
+    "./*/json-ld": "./src/*/json-ld.ts",
     "./*.schema": "./src/*.schema.ts",
     "./*.groq": "./src/*.groq.ts",
     "./internal/lucide-icon-preview": "./src/internal/lucide-icon-preview.tsx",

--- a/packages/sanity-blocks/src/cta/cta-markdown.test.tsx
+++ b/packages/sanity-blocks/src/cta/cta-markdown.test.tsx
@@ -1,0 +1,65 @@
+import { ctaToMarkdown } from "./markdown";
+
+const para = (text: string) => [
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text }],
+  },
+];
+
+test("ctaToMarkdown returns empty string for a fully empty block", () => {
+  expect(ctaToMarkdown({}, {})).toBe("");
+});
+
+test("ctaToMarkdown renders eyebrow, title, and richText joined by blank lines", () => {
+  const result = ctaToMarkdown(
+    {
+      eyebrow: "New",
+      title: "Launch",
+      richText: para("Get started today."),
+    },
+    {}
+  );
+  expect(result).toBe("**New**\n\n## Launch\n\nGet started today.");
+});
+
+test("ctaToMarkdown escapes markdown chars in eyebrow", () => {
+  const result = ctaToMarkdown({ eyebrow: "#1 _Pick_" }, {});
+  expect(result).toBe("**\\#1 \\_Pick\\_**");
+});
+
+test("ctaToMarkdown escapes markdown chars in title", () => {
+  const result = ctaToMarkdown({ title: "user_name & [more]" }, {});
+  expect(result).toBe("## user\\_name & \\[more\\]");
+});
+
+test("ctaToMarkdown renders buttons as a Markdown list", () => {
+  const result = ctaToMarkdown(
+    {
+      title: "CTA",
+      buttons: [
+        { _key: "b1", text: "Start", href: "/start" },
+        { _key: "b2", text: "Learn more", href: "#" },
+      ],
+    },
+    {}
+  );
+  expect(result).toContain("- [Start](/start)");
+  expect(result).toContain("- Learn more");
+  expect(result).not.toContain("(#)");
+});
+
+test("ctaToMarkdown handles undefined richText without throwing", () => {
+  expect(() =>
+    ctaToMarkdown({ title: "T", richText: undefined }, {})
+  ).not.toThrow();
+});
+
+test("ctaToMarkdown emits no HTML or JSX tags", () => {
+  const result = ctaToMarkdown(
+    { eyebrow: "E", title: "T", richText: para("Body.") },
+    {}
+  );
+  expect(result).not.toMatch(/<[A-Za-z]/);
+});

--- a/packages/sanity-blocks/src/cta/markdown.ts
+++ b/packages/sanity-blocks/src/cta/markdown.ts
@@ -1,0 +1,21 @@
+import {
+  type MarkdownBlock,
+  type MarkdownOptions,
+  buttonsToMarkdown,
+  eyebrowToMarkdown,
+  headingToMarkdown,
+  joinSections,
+} from "../internal/markdown";
+import { portableTextToMarkdown } from "../internal/portable-text-to-markdown";
+
+export function ctaToMarkdown(
+  block: MarkdownBlock,
+  options: MarkdownOptions
+): string {
+  return joinSections([
+    eyebrowToMarkdown(block.eyebrow),
+    headingToMarkdown(block.title, 2),
+    portableTextToMarkdown(block.richText, options),
+    buttonsToMarkdown(block.buttons),
+  ]);
+}

--- a/packages/sanity-blocks/src/faq-accordion/faq-accordion-markdown.test.tsx
+++ b/packages/sanity-blocks/src/faq-accordion/faq-accordion-markdown.test.tsx
@@ -1,0 +1,118 @@
+import { faqAccordionToMarkdown } from "./markdown";
+
+const para = (text: string) => [
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text }],
+  },
+];
+
+test("faqAccordionToMarkdown returns empty string for a fully empty block", () => {
+  expect(faqAccordionToMarkdown({}, {})).toBe("");
+});
+
+test("faqAccordionToMarkdown renders eyebrow and title with no faqs", () => {
+  const result = faqAccordionToMarkdown({ eyebrow: "Help", title: "FAQ" }, {});
+  expect(result).toBe("**Help**\n\n## FAQ");
+});
+
+test("faqAccordionToMarkdown renders subtitle below title", () => {
+  const result = faqAccordionToMarkdown(
+    { title: "FAQ", subtitle: "Your questions answered" },
+    {}
+  );
+  expect(result).toContain("Your questions answered");
+});
+
+test("faqAccordionToMarkdown escapes markdown chars in subtitle", () => {
+  const result = faqAccordionToMarkdown(
+    { title: "FAQ", subtitle: "Ask [us] anything_here | now" },
+    {}
+  );
+  expect(result).toContain("Ask \\[us\\] anything\\_here \\| now");
+});
+
+test("faqAccordionToMarkdown renders each faq as h3 followed by its answer", () => {
+  const result = faqAccordionToMarkdown(
+    {
+      title: "FAQ",
+      faqs: [{ title: "What?", richText: para("An answer.") }],
+    },
+    {}
+  );
+  expect(result).toContain("### What?");
+  expect(result).toContain("An answer.");
+});
+
+test("faqAccordionToMarkdown skips faqs that have no title", () => {
+  const result = faqAccordionToMarkdown(
+    {
+      title: "FAQ",
+      faqs: [
+        { title: "", richText: para("Orphan body") },
+        { richText: para("Also orphan") },
+        { title: "Valid Q", richText: para("Yes.") },
+      ],
+    },
+    {}
+  );
+  expect(result).not.toContain("Orphan body");
+  expect(result).not.toContain("Also orphan");
+  expect(result).toContain("### Valid Q");
+});
+
+test("faqAccordionToMarkdown handles null faqs without throwing", () => {
+  expect(() =>
+    faqAccordionToMarkdown({ title: "FAQ", faqs: null }, {})
+  ).not.toThrow();
+});
+
+test("faqAccordionToMarkdown prefers link description over link title", () => {
+  const result = faqAccordionToMarkdown(
+    {
+      title: "FAQ",
+      faqs: [{ title: "Q", richText: para("A") }],
+      link: { title: "MoreX", description: "See all FAQs", href: "/faq" },
+    },
+    {}
+  );
+  expect(result).toContain("[See all FAQs](/faq)");
+  expect(result).not.toContain("MoreX");
+});
+
+test("faqAccordionToMarkdown uses link title when description is absent", () => {
+  const result = faqAccordionToMarkdown(
+    {
+      title: "FAQ",
+      faqs: [{ title: "Q", richText: para("A") }],
+      link: { title: "More", href: "/faq" },
+    },
+    {}
+  );
+  expect(result).toContain("[More](/faq)");
+});
+
+test("faqAccordionToMarkdown renders link as plain text when href is '#'", () => {
+  const result = faqAccordionToMarkdown(
+    {
+      title: "FAQ",
+      faqs: [{ title: "Q", richText: para("A") }],
+      link: { title: "Label", href: "#" },
+    },
+    {}
+  );
+  expect(result).toContain("Label");
+  expect(result).not.toContain("(#)");
+});
+
+test("faqAccordionToMarkdown emits no HTML or JSX tags", () => {
+  const result = faqAccordionToMarkdown(
+    {
+      title: "FAQ",
+      faqs: [{ title: "Q?", richText: para("Answer text.") }],
+    },
+    {}
+  );
+  expect(result).not.toMatch(/<[A-Za-z]/);
+});

--- a/packages/sanity-blocks/src/faq-accordion/json-ld.test.tsx
+++ b/packages/sanity-blocks/src/faq-accordion/json-ld.test.tsx
@@ -1,0 +1,113 @@
+import { faqAccordionToJsonLd } from "./json-ld";
+
+type JsonLdQuestion = {
+  "@type": string;
+  name: unknown;
+  acceptedAnswer: unknown;
+};
+type JsonLdAnswer = { "@type": string; text: unknown };
+
+const block = (
+  _type: string,
+  children: Array<{ _type: string; text?: string }>
+) => ({ _type, children });
+
+const span = (text: string) => ({ _type: "span", text });
+
+function questions(
+  result: ReturnType<typeof faqAccordionToJsonLd>
+): JsonLdQuestion[] {
+  return result?.mainEntity as unknown as JsonLdQuestion[];
+}
+
+test("returns null for empty or missing faqs", () => {
+  expect(faqAccordionToJsonLd({ faqs: [] })).toBeNull();
+  expect(faqAccordionToJsonLd({})).toBeNull();
+  expect(faqAccordionToJsonLd({ faqs: null })).toBeNull();
+});
+
+test("returns null when no faq has both title and richText", () => {
+  expect(
+    faqAccordionToJsonLd({
+      faqs: [
+        { title: "Q?", richText: null },
+        { richText: [block("block", [span("no title")])] },
+      ],
+    })
+  ).toBeNull();
+});
+
+test("builds FAQPage with mainEntity for a valid faq", () => {
+  const result = faqAccordionToJsonLd({
+    faqs: [
+      {
+        title: "What is JSON-LD?",
+        richText: [block("block", [span("A serialization format.")])],
+      },
+    ],
+  });
+
+  expect(result).not.toBeNull();
+  expect(result?.["@type"]).toBe("FAQPage");
+  const entities = questions(result);
+  expect(entities).toHaveLength(1);
+  expect(entities[0]?.["@type"]).toBe("Question");
+  expect(entities[0]?.name).toBe("What is JSON-LD?");
+  const answer = entities[0]?.acceptedAnswer as JsonLdAnswer;
+  expect(answer["@type"]).toBe("Answer");
+  expect(answer.text).toBe("A serialization format.");
+});
+
+test("filters out faqs missing title or richText, keeps valid ones", () => {
+  const result = faqAccordionToJsonLd({
+    faqs: [
+      {
+        title: "Valid?",
+        richText: [block("block", [span("Yes.")])],
+      },
+      { title: null, richText: [block("block", [span("no title")])] },
+      { title: "No body?", richText: null },
+    ],
+  });
+
+  expect(result).not.toBeNull();
+  const entities = questions(result);
+  expect(entities).toHaveLength(1);
+  expect(entities[0]?.name).toBe("Valid?");
+});
+
+test("joins multiple spans across multiple blocks", () => {
+  const result = faqAccordionToJsonLd({
+    faqs: [
+      {
+        title: "Multi-block?",
+        richText: [
+          block("block", [span("First. "), span("Second.")]),
+          block("block", [span("Third.")]),
+        ],
+      },
+    ],
+  });
+
+  const entities = questions(result);
+  const answer = entities[0]?.acceptedAnswer as JsonLdAnswer;
+  expect(answer.text).toBe("First. Second. Third.");
+});
+
+test("ignores non-block rich text nodes", () => {
+  const result = faqAccordionToJsonLd({
+    faqs: [
+      {
+        title: "Image block?",
+        richText: [
+          { _type: "image", children: [span("should be ignored")] },
+          block("block", [span("Only text.")]),
+        ],
+      },
+    ],
+  });
+
+  const entities = questions(result);
+  const answer = entities[0]?.acceptedAnswer as JsonLdAnswer;
+  expect(answer.text).toBe("Only text.");
+});

--- a/packages/sanity-blocks/src/faq-accordion/json-ld.ts
+++ b/packages/sanity-blocks/src/faq-accordion/json-ld.ts
@@ -1,0 +1,55 @@
+import type { Answer, FAQPage, Question, WithContext } from "schema-dts";
+
+type RichTextChild = { _type: string; text?: string };
+type RichTextBlock = { _type: string; children?: RichTextChild[] };
+
+type FaqInput = { title?: string | null; richText?: RichTextBlock[] | null };
+
+export type FaqAccordionInput = { faqs?: FaqInput[] | null };
+
+function extractPlainText(richText: RichTextBlock[]): string {
+  return richText
+    .filter((block) => block._type === "block" && Array.isArray(block.children))
+    .map((block) =>
+      (block.children ?? [])
+        .filter((child) => child._type === "span")
+        .map((child) => child.text ?? "")
+        .join("")
+    )
+    .join(" ")
+    .trim();
+}
+
+/**
+ * Builds FAQPage JSON-LD from a faqAccordion block's data.
+ *
+ * PRECONDITION: `block` must already be stega-cleaned by the caller. This is a
+ * pure serializer in a headless package and intentionally does not import
+ * next-sanity's `stegaClean`; passing stega-encoded fields would leak invisible
+ * characters into the emitted JSON-LD. The app boundary
+ * (page-builder-json-ld.tsx) owns the cleaning.
+ */
+export function faqAccordionToJsonLd(
+  block: FaqAccordionInput
+): WithContext<FAQPage> | null {
+  const validFaqs = (block.faqs ?? []).filter(
+    (faq): faq is FaqInput & { title: string; richText: RichTextBlock[] } =>
+      Boolean(faq.title && faq.richText)
+  );
+  if (!validFaqs.length) return null;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: validFaqs.map(
+      (faq): Question => ({
+        "@type": "Question",
+        name: faq.title,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: extractPlainText(faq.richText),
+        } as Answer,
+      })
+    ),
+  };
+}

--- a/packages/sanity-blocks/src/faq-accordion/markdown.ts
+++ b/packages/sanity-blocks/src/faq-accordion/markdown.ts
@@ -1,0 +1,40 @@
+import {
+  type MarkdownBlock,
+  type MarkdownOptions,
+  eyebrowToMarkdown,
+  headingToMarkdown,
+  joinSections,
+  mdLink,
+} from "../internal/markdown";
+import {
+  escapeMarkdown,
+  portableTextToMarkdown,
+} from "../internal/portable-text-to-markdown";
+
+export function faqAccordionToMarkdown(
+  block: MarkdownBlock,
+  options: MarkdownOptions
+): string {
+  const faqs = (block.faqs ?? [])
+    .filter((faq) => faq?.title)
+    .map((faq) =>
+      joinSections([
+        headingToMarkdown(faq.title, 3),
+        portableTextToMarkdown(faq.richText, options),
+      ])
+    );
+
+  const link = block.link;
+  const linkLabel = (link?.description || link?.title || "").trim();
+  const linkMarkdown = linkLabel ? mdLink(linkLabel, link?.href) : "";
+
+  const subtitle = (block.subtitle ?? "").trim();
+
+  return joinSections([
+    eyebrowToMarkdown(block.eyebrow),
+    headingToMarkdown(block.title, 2),
+    subtitle ? escapeMarkdown(subtitle) : "",
+    ...faqs,
+    linkMarkdown,
+  ]);
+}

--- a/packages/sanity-blocks/src/feature-cards-icon/feature-cards-icon-markdown.test.tsx
+++ b/packages/sanity-blocks/src/feature-cards-icon/feature-cards-icon-markdown.test.tsx
@@ -1,0 +1,91 @@
+import { featureCardsIconToMarkdown } from "./markdown";
+
+const para = (text: string) => [
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text }],
+  },
+];
+
+test("featureCardsIconToMarkdown returns empty string for a fully empty block", () => {
+  expect(featureCardsIconToMarkdown({}, {})).toBe("");
+});
+
+test("featureCardsIconToMarkdown renders a section title alone", () => {
+  expect(featureCardsIconToMarkdown({ title: "Features" }, {})).toBe(
+    "## Features"
+  );
+});
+
+test("featureCardsIconToMarkdown renders eyebrow above the title", () => {
+  const result = featureCardsIconToMarkdown(
+    { eyebrow: "Why us", title: "Features" },
+    {}
+  );
+  expect(result).toBe("**Why us**\n\n## Features");
+});
+
+test("featureCardsIconToMarkdown renders each card as an h3 section", () => {
+  const result = featureCardsIconToMarkdown(
+    {
+      title: "Features",
+      cards: [
+        { _key: "c1", title: "Fast", richText: para("Very fast.") },
+        { _key: "c2", title: "Secure", richText: para("Very secure.") },
+      ],
+    },
+    {}
+  );
+  expect(result).toContain("### Fast");
+  expect(result).toContain("Very fast.");
+  expect(result).toContain("### Secure");
+  expect(result).toContain("Very secure.");
+});
+
+test("featureCardsIconToMarkdown drops the icon field from output", () => {
+  const result = featureCardsIconToMarkdown(
+    {
+      cards: [{ _key: "c1", title: "Card", icon: "bolt" }],
+    },
+    {}
+  );
+  expect(result).not.toContain("bolt");
+});
+
+test("featureCardsIconToMarkdown still renders richText for a card with no title", () => {
+  const result = featureCardsIconToMarkdown(
+    {
+      cards: [{ _key: "c1", richText: para("Body without heading.") }],
+    },
+    {}
+  );
+  expect(result).toContain("Body without heading.");
+});
+
+test("featureCardsIconToMarkdown handles null cards without throwing", () => {
+  expect(() =>
+    featureCardsIconToMarkdown({ title: "T", cards: null }, {})
+  ).not.toThrow();
+});
+
+test("featureCardsIconToMarkdown escapes markdown chars in card title", () => {
+  const result = featureCardsIconToMarkdown(
+    {
+      cards: [{ _key: "c1", title: "user_name [feature]" }],
+    },
+    {}
+  );
+  expect(result).toContain("### user\\_name \\[feature\\]");
+});
+
+test("featureCardsIconToMarkdown emits no HTML or JSX tags", () => {
+  const result = featureCardsIconToMarkdown(
+    {
+      title: "T",
+      cards: [{ _key: "c1", title: "Card", richText: para("Body.") }],
+    },
+    {}
+  );
+  expect(result).not.toMatch(/<[A-Za-z]/);
+});

--- a/packages/sanity-blocks/src/feature-cards-icon/markdown.ts
+++ b/packages/sanity-blocks/src/feature-cards-icon/markdown.ts
@@ -1,0 +1,27 @@
+import {
+  type MarkdownBlock,
+  type MarkdownOptions,
+  eyebrowToMarkdown,
+  headingToMarkdown,
+  joinSections,
+} from "../internal/markdown";
+import { portableTextToMarkdown } from "../internal/portable-text-to-markdown";
+
+export function featureCardsIconToMarkdown(
+  block: MarkdownBlock,
+  options: MarkdownOptions
+): string {
+  const cards = (block.cards ?? []).map((card) =>
+    joinSections([
+      headingToMarkdown(card.title, 3),
+      portableTextToMarkdown(card.richText, options),
+    ])
+  );
+
+  return joinSections([
+    eyebrowToMarkdown(block.eyebrow),
+    headingToMarkdown(block.title, 2),
+    portableTextToMarkdown(block.richText, options),
+    ...cards,
+  ]);
+}

--- a/packages/sanity-blocks/src/hero/hero-markdown.test.tsx
+++ b/packages/sanity-blocks/src/hero/hero-markdown.test.tsx
@@ -1,0 +1,77 @@
+import { heroToMarkdown } from "./markdown";
+
+const para = (text: string) => [
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text }],
+  },
+];
+
+test("heroToMarkdown returns empty string for a fully empty block", () => {
+  expect(heroToMarkdown({}, {})).toBe("");
+});
+
+test("heroToMarkdown renders badge, title, and richText", () => {
+  const result = heroToMarkdown(
+    { badge: "v2", title: "Welcome", richText: para("Hello!") },
+    {}
+  );
+  expect(result).toBe("**v2**\n\n## Welcome\n\nHello!");
+});
+
+test("heroToMarkdown escapes markdown chars in badge", () => {
+  const result = heroToMarkdown({ badge: "#1 _top_" }, {});
+  expect(result).toBe("**\\#1 \\_top\\_**");
+});
+
+test("heroToMarkdown escapes markdown chars in title", () => {
+  const result = heroToMarkdown({ title: "[New] Release" }, {});
+  expect(result).toBe("## \\[New\\] Release");
+});
+
+test("heroToMarkdown renders image markup when resolver is provided", () => {
+  const result = heroToMarkdown(
+    { title: "H", image: { id: "img1", alt: "Hero image" } },
+    { resolveImageUrl: (img) => `https://cdn.example.com/${img.id}.webp` }
+  );
+  expect(result).toContain("![Hero image](https://cdn.example.com/img1.webp)");
+});
+
+test("heroToMarkdown falls back to alt text when no resolver is provided", () => {
+  const result = heroToMarkdown(
+    { title: "H", image: { id: "img1", alt: "Fallback text" } },
+    {}
+  );
+  expect(result).toContain("Fallback text");
+  expect(result).not.toContain("![");
+});
+
+test("heroToMarkdown omits image section entirely when image is absent", () => {
+  const result = heroToMarkdown({ title: "No image" }, {});
+  expect(result).toBe("## No image");
+  expect(result).not.toContain("![");
+});
+
+test("heroToMarkdown renders a hash-href button as plain text", () => {
+  const result = heroToMarkdown(
+    {
+      buttons: [
+        { text: "Go", href: "/go" },
+        { text: "Noop", href: "#" },
+      ],
+    },
+    {}
+  );
+  expect(result).toContain("- [Go](/go)");
+  expect(result).toContain("- Noop");
+  expect(result).not.toContain("(#)");
+});
+
+test("heroToMarkdown does not emit HTML or JSX tags", () => {
+  const result = heroToMarkdown(
+    { badge: "B", title: "T", richText: para("Body.") },
+    {}
+  );
+  expect(result).not.toMatch(/<[A-Za-z]/);
+});

--- a/packages/sanity-blocks/src/hero/markdown.ts
+++ b/packages/sanity-blocks/src/hero/markdown.ts
@@ -1,0 +1,23 @@
+import {
+  type MarkdownBlock,
+  type MarkdownOptions,
+  buttonsToMarkdown,
+  eyebrowToMarkdown,
+  headingToMarkdown,
+  imageToMarkdown,
+  joinSections,
+} from "../internal/markdown";
+import { portableTextToMarkdown } from "../internal/portable-text-to-markdown";
+
+export function heroToMarkdown(
+  block: MarkdownBlock,
+  options: MarkdownOptions
+): string {
+  return joinSections([
+    eyebrowToMarkdown(block.badge),
+    headingToMarkdown(block.title, 2),
+    portableTextToMarkdown(block.richText, options),
+    imageToMarkdown(block.image, options),
+    buttonsToMarkdown(block.buttons),
+  ]);
+}

--- a/packages/sanity-blocks/src/image-link-cards/image-link-cards-markdown.test.tsx
+++ b/packages/sanity-blocks/src/image-link-cards/image-link-cards-markdown.test.tsx
@@ -1,0 +1,121 @@
+import { imageLinkCardsToMarkdown } from "./markdown";
+
+test("imageLinkCardsToMarkdown returns empty string for a fully empty block", () => {
+  expect(imageLinkCardsToMarkdown({}, {})).toBe("");
+});
+
+test("imageLinkCardsToMarkdown renders eyebrow and section title", () => {
+  const result = imageLinkCardsToMarkdown(
+    { eyebrow: "Explore", title: "Components" },
+    {}
+  );
+  expect(result).toBe("**Explore**\n\n## Components");
+});
+
+test("imageLinkCardsToMarkdown renders linked card headings", () => {
+  const result = imageLinkCardsToMarkdown(
+    { cards: [{ _key: "c1", title: "Hero", href: "/hero" }] },
+    {}
+  );
+  expect(result).toContain("### [Hero](/hero)");
+});
+
+test("imageLinkCardsToMarkdown filters cards without an href", () => {
+  const result = imageLinkCardsToMarkdown(
+    {
+      cards: [
+        { _key: "c1", title: "No link" },
+        { _key: "c2", title: "Has link", href: "/page" },
+      ],
+    },
+    {}
+  );
+  expect(result).not.toContain("No link");
+  expect(result).toContain("### [Has link](/page)");
+});
+
+test("imageLinkCardsToMarkdown includes card description", () => {
+  const result = imageLinkCardsToMarkdown(
+    {
+      cards: [
+        {
+          _key: "c1",
+          title: "Card",
+          href: "/card",
+          description: "A reusable section.",
+        },
+      ],
+    },
+    {}
+  );
+  expect(result).toContain("A reusable section.");
+});
+
+test("imageLinkCardsToMarkdown escapes markdown chars in description", () => {
+  const result = imageLinkCardsToMarkdown(
+    {
+      cards: [
+        {
+          _key: "c1",
+          title: "Card",
+          href: "/card",
+          description: "Supports _italic_ and [links].",
+        },
+      ],
+    },
+    {}
+  );
+  expect(result).toContain("Supports \\_italic\\_ and \\[links\\].");
+});
+
+test("imageLinkCardsToMarkdown renders card image when a resolver is provided", () => {
+  const result = imageLinkCardsToMarkdown(
+    {
+      cards: [
+        {
+          _key: "c1",
+          title: "Card",
+          href: "/card",
+          image: { id: "img1", alt: "Preview" },
+        },
+      ],
+    },
+    { resolveImageUrl: (img) => `https://cdn.example.com/${img.id}.webp` }
+  );
+  expect(result).toContain("![Preview](https://cdn.example.com/img1.webp)");
+});
+
+test("imageLinkCardsToMarkdown falls back to alt text for card image when no resolver", () => {
+  const result = imageLinkCardsToMarkdown(
+    {
+      cards: [
+        {
+          _key: "c1",
+          title: "Card",
+          href: "/card",
+          image: { id: "img1", alt: "Fallback" },
+        },
+      ],
+    },
+    {}
+  );
+  expect(result).toContain("Fallback");
+  expect(result).not.toContain("![");
+});
+
+test("imageLinkCardsToMarkdown drops '#' placeholder-href cards entirely", () => {
+  // href="#" is now filtered out (consistent with how buttons treat "#").
+  const result = imageLinkCardsToMarkdown(
+    { cards: [{ _key: "c1", title: "Hash card", href: "#" }] },
+    {}
+  );
+  expect(result).toBe("");
+});
+
+test("imageLinkCardsToMarkdown emits no HTML or JSX tags", () => {
+  const result = imageLinkCardsToMarkdown(
+    { title: "T", cards: [{ _key: "c1", title: "Card", href: "/card" }] },
+    {}
+  );
+  expect(result).not.toMatch(/<[A-Za-z]/);
+});

--- a/packages/sanity-blocks/src/image-link-cards/markdown.ts
+++ b/packages/sanity-blocks/src/image-link-cards/markdown.ts
@@ -1,0 +1,37 @@
+import {
+  type MarkdownBlock,
+  type MarkdownOptions,
+  cardHeading,
+  eyebrowToMarkdown,
+  headingToMarkdown,
+  imageToMarkdown,
+  joinSections,
+} from "../internal/markdown";
+import {
+  escapeMarkdown,
+  portableTextToMarkdown,
+} from "../internal/portable-text-to-markdown";
+
+export function imageLinkCardsToMarkdown(
+  block: MarkdownBlock,
+  options: MarkdownOptions
+): string {
+  const cards = (block.cards ?? [])
+    .filter((card) => card.href && card.href !== "#")
+    .map((card) => {
+      const title = (card.title ?? "").trim();
+      const description = (card.description ?? "").trim();
+      return joinSections([
+        cardHeading(title, card.href),
+        description ? escapeMarkdown(description) : "",
+        imageToMarkdown(card.image, options),
+      ]);
+    });
+
+  return joinSections([
+    eyebrowToMarkdown(block.eyebrow),
+    headingToMarkdown(block.title, 2),
+    portableTextToMarkdown(block.richText, options),
+    ...cards,
+  ]);
+}

--- a/packages/sanity-blocks/src/internal/markdown.test.tsx
+++ b/packages/sanity-blocks/src/internal/markdown.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for the shared markdown-helper utilities in ./markdown.ts.
+ * These helpers are used by every per-block serializer, so correctness here
+ * protects the entire pipeline.
+ */
+
+import {
+  buttonsToMarkdown,
+  cardHeading,
+  eyebrowToMarkdown,
+  headingToMarkdown,
+  imageToMarkdown,
+  joinSections,
+  mdLink,
+  type MarkdownImage,
+  type MarkdownOptions,
+} from "./markdown";
+
+// ─── joinSections ────────────────────────────────────────────────────────────
+
+test("joinSections returns empty string for an empty array", () => {
+  expect(joinSections([])).toBe("");
+});
+
+test("joinSections filters null, undefined, and whitespace-only entries", () => {
+  expect(joinSections([null, undefined, "  ", ""])).toBe("");
+});
+
+test("joinSections joins non-empty sections with a blank line", () => {
+  expect(joinSections(["A", "B", "C"])).toBe("A\n\nB\n\nC");
+});
+
+test("joinSections returns a single non-empty section unchanged", () => {
+  expect(joinSections(["only"])).toBe("only");
+});
+
+test("joinSections skips whitespace-only entries between real sections", () => {
+  expect(joinSections(["First", "   ", "Second"])).toBe("First\n\nSecond");
+});
+
+// ─── eyebrowToMarkdown ───────────────────────────────────────────────────────
+
+test("eyebrowToMarkdown returns empty for null/undefined/empty/whitespace", () => {
+  expect(eyebrowToMarkdown(null)).toBe("");
+  expect(eyebrowToMarkdown(undefined)).toBe("");
+  expect(eyebrowToMarkdown("")).toBe("");
+  expect(eyebrowToMarkdown("   ")).toBe("");
+});
+
+test("eyebrowToMarkdown wraps plain text in bold markers", () => {
+  expect(eyebrowToMarkdown("New")).toBe("**New**");
+});
+
+test("eyebrowToMarkdown escapes # inside bold", () => {
+  expect(eyebrowToMarkdown("Say #1")).toBe("**Say \\#1**");
+});
+
+test("eyebrowToMarkdown escapes underscores inside bold", () => {
+  expect(eyebrowToMarkdown("_italic_")).toBe("**\\_italic\\_**");
+});
+
+test("eyebrowToMarkdown escapes square brackets inside bold", () => {
+  expect(eyebrowToMarkdown("[link]")).toBe("**\\[link\\]**");
+});
+
+test("eyebrowToMarkdown escapes angle brackets (prevents HTML injection)", () => {
+  expect(eyebrowToMarkdown("<script>")).toBe("**\\<script\\>**");
+});
+
+test("eyebrowToMarkdown escapes backtick and pipe", () => {
+  expect(eyebrowToMarkdown("`code` | pipe")).toBe("**\\`code\\` \\| pipe**");
+});
+
+// ─── headingToMarkdown ───────────────────────────────────────────────────────
+
+test("headingToMarkdown returns empty for null/undefined/whitespace", () => {
+  expect(headingToMarkdown(null, 2)).toBe("");
+  expect(headingToMarkdown(undefined, 2)).toBe("");
+  expect(headingToMarkdown("  ", 2)).toBe("");
+});
+
+test("headingToMarkdown emits ## prefix for level 2", () => {
+  expect(headingToMarkdown("About Us", 2)).toBe("## About Us");
+});
+
+test("headingToMarkdown emits ### prefix for level 3", () => {
+  expect(headingToMarkdown("Card Title", 3)).toBe("### Card Title");
+});
+
+test("headingToMarkdown escapes underscores in title", () => {
+  expect(headingToMarkdown("user_name field", 2)).toBe("## user\\_name field");
+});
+
+test("headingToMarkdown escapes square brackets in title", () => {
+  expect(headingToMarkdown("[Tag] heading", 2)).toBe("## \\[Tag\\] heading");
+});
+
+test("headingToMarkdown escapes leading # so it is not a nested heading", () => {
+  expect(headingToMarkdown("#hashtag", 2)).toBe("## \\#hashtag");
+});
+
+test("headingToMarkdown escapes asterisks in title", () => {
+  expect(headingToMarkdown("*bold* text", 3)).toBe("### \\*bold\\* text");
+});
+
+test("headingToMarkdown escapes angle brackets (prevents HTML injection)", () => {
+  expect(headingToMarkdown("<script>alert(1)</script>", 2)).toBe(
+    "## \\<script\\>alert(1)\\</script\\>"
+  );
+});
+
+// ─── buttonsToMarkdown ───────────────────────────────────────────────────────
+
+test("buttonsToMarkdown returns empty for null and undefined", () => {
+  expect(buttonsToMarkdown(null)).toBe("");
+  expect(buttonsToMarkdown(undefined)).toBe("");
+});
+
+test("buttonsToMarkdown returns empty for an empty array", () => {
+  expect(buttonsToMarkdown([])).toBe("");
+});
+
+test("buttonsToMarkdown renders a valid button as a Markdown link list item", () => {
+  expect(buttonsToMarkdown([{ text: "Get started", href: "/start" }])).toBe(
+    "- [Get started](/start)"
+  );
+});
+
+test("buttonsToMarkdown renders plain text when href is '#'", () => {
+  expect(buttonsToMarkdown([{ text: "Click me", href: "#" }])).toBe(
+    "- Click me"
+  );
+});
+
+test("buttonsToMarkdown renders plain text when href is absent", () => {
+  expect(buttonsToMarkdown([{ text: "Anchor only" }])).toBe("- Anchor only");
+});
+
+test("buttonsToMarkdown uses href as label when text is empty and href is valid", () => {
+  expect(buttonsToMarkdown([{ href: "/docs" }])).toBe("- [/docs](/docs)");
+});
+
+test("buttonsToMarkdown filters buttons with no text and no actionable href", () => {
+  expect(buttonsToMarkdown([{ text: "", href: "#" }])).toBe("");
+  expect(buttonsToMarkdown([{ text: "" }])).toBe("");
+  expect(buttonsToMarkdown([{}])).toBe("");
+});
+
+test("buttonsToMarkdown escapes markdown chars in button text", () => {
+  expect(buttonsToMarkdown([{ text: "user_name [docs]", href: "/path" }])).toBe(
+    "- [user\\_name \\[docs\\]](/path)"
+  );
+});
+
+test("buttonsToMarkdown wraps hrefs containing parentheses in angle brackets", () => {
+  expect(buttonsToMarkdown([{ text: "See", href: "/docs/foo_(bar)" }])).toBe(
+    "- [See](</docs/foo_(bar)>)"
+  );
+});
+
+test("buttonsToMarkdown joins multiple buttons with a newline, not a blank line", () => {
+  expect(
+    buttonsToMarkdown([
+      { text: "Primary", href: "/primary" },
+      { text: "Secondary", href: "#" },
+    ])
+  ).toBe("- [Primary](/primary)\n- Secondary");
+});
+
+// ─── imageToMarkdown ─────────────────────────────────────────────────────────
+
+const resolveImageUrl: MarkdownOptions["resolveImageUrl"] = (img) =>
+  `https://cdn.example.com/${img.id}.webp`;
+
+test("imageToMarkdown returns empty for null or undefined", () => {
+  expect(imageToMarkdown(null, {})).toBe("");
+  expect(imageToMarkdown(undefined, {})).toBe("");
+});
+
+test("imageToMarkdown returns empty when id, alt, and caption are all absent", () => {
+  expect(imageToMarkdown({}, {})).toBe("");
+  expect(imageToMarkdown({ id: null, alt: "", caption: "" }, {})).toBe("");
+});
+
+test("imageToMarkdown falls back to alt text when no resolver is provided", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "A photo" };
+  expect(imageToMarkdown(img, {})).toBe("A photo");
+});
+
+test("imageToMarkdown falls back to caption when alt is empty and there is no resolver", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "", caption: "Nice view" };
+  expect(imageToMarkdown(img, {})).toBe("Nice view");
+});
+
+test("imageToMarkdown emits image markdown when resolver returns a URL", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "A photo" };
+  expect(imageToMarkdown(img, { resolveImageUrl })).toBe(
+    "![A photo](https://cdn.example.com/abc123.webp)"
+  );
+});
+
+test("imageToMarkdown escapes square brackets in alt text", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "A [diagram]" };
+  expect(imageToMarkdown(img, { resolveImageUrl })).toBe(
+    "![A \\[diagram\\]](https://cdn.example.com/abc123.webp)"
+  );
+});
+
+test("imageToMarkdown escapes markdown chars in fallback alt text", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "user_name [tag]" };
+  expect(imageToMarkdown(img, {})).toBe("user\\_name \\[tag\\]");
+});
+
+test("imageToMarkdown falls back to text when resolver returns null", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "Fallback" };
+  expect(imageToMarkdown(img, { resolveImageUrl: () => null })).toBe(
+    "Fallback"
+  );
+});
+
+test("imageToMarkdown falls back to text when resolver returns undefined", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "Fallback" };
+  expect(imageToMarkdown(img, { resolveImageUrl: () => undefined })).toBe(
+    "Fallback"
+  );
+});
+
+test("imageToMarkdown wraps image URLs with spaces in angle brackets", () => {
+  const img: MarkdownImage = { id: "abc123", alt: "Photo" };
+  expect(
+    imageToMarkdown(img, {
+      resolveImageUrl: () => "https://cdn.example.com/my file.webp",
+    })
+  ).toBe("![Photo](<https://cdn.example.com/my file.webp>)");
+});
+
+test("imageToMarkdown skips the resolver when id is null", () => {
+  const img: MarkdownImage = { id: null, alt: "No id" };
+  expect(imageToMarkdown(img, { resolveImageUrl })).toBe("No id");
+});
+
+// ─── mdLink ──────────────────────────────────────────────────────────────────
+
+test("mdLink returns a Markdown link for a valid href", () => {
+  expect(mdLink("Docs", "/docs")).toBe("[Docs](/docs)");
+});
+
+test("mdLink returns escaped plain text for '#' href", () => {
+  expect(mdLink("Anchor", "#")).toBe("Anchor");
+});
+
+test("mdLink returns escaped plain text for null href", () => {
+  expect(mdLink("Label", null)).toBe("Label");
+});
+
+test("mdLink returns escaped plain text for undefined href", () => {
+  expect(mdLink("Label", undefined)).toBe("Label");
+});
+
+test("mdLink returns escaped plain text for empty-string href", () => {
+  expect(mdLink("Label", "")).toBe("Label");
+});
+
+test("mdLink escapes markdown metacharacters in the label", () => {
+  expect(mdLink("user_name [tag]", "/path")).toBe(
+    "[user\\_name \\[tag\\]](/path)"
+  );
+});
+
+test("mdLink wraps href with parentheses in angle brackets", () => {
+  expect(mdLink("Link", "/wiki/foo_(bar)")).toBe("[Link](</wiki/foo_(bar)>)");
+});
+
+// ─── cardHeading ─────────────────────────────────────────────────────────────
+
+test("cardHeading returns a linked h3 when title and href are both valid", () => {
+  expect(cardHeading("Hero Block", "/hero")).toBe("### [Hero Block](/hero)");
+});
+
+test("cardHeading returns plain h3 (no link) when href is '#'", () => {
+  expect(cardHeading("Hero Block", "#")).toBe("### Hero Block");
+});
+
+test("cardHeading returns plain h3 when href is null", () => {
+  expect(cardHeading("Card", null)).toBe("### Card");
+});
+
+test("cardHeading returns plain h3 when href is undefined", () => {
+  expect(cardHeading("Card", undefined)).toBe("### Card");
+});
+
+test("cardHeading escapes markdown chars in title", () => {
+  expect(cardHeading("user_name [special]", "/path")).toBe(
+    "### [user\\_name \\[special\\]](/path)"
+  );
+});
+
+test("cardHeading uses the href as heading text when title is empty", () => {
+  expect(cardHeading("", "/features")).toBe("### /features");
+});
+
+test("cardHeading returns empty string when title is empty and href is '#'", () => {
+  expect(cardHeading("", "#")).toBe("");
+});
+
+test("cardHeading returns empty string when title is empty and href is null", () => {
+  expect(cardHeading("", null)).toBe("");
+  expect(cardHeading("", undefined)).toBe("");
+});
+
+test("cardHeading wraps paren-containing href in angle brackets when title is empty", () => {
+  expect(cardHeading("", "/docs/foo_(bar)")).toBe("### </docs/foo_(bar)>");
+});

--- a/packages/sanity-blocks/src/internal/markdown.ts
+++ b/packages/sanity-blocks/src/internal/markdown.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared helpers and types for page-builder Markdown serialization.
+ * Block-level serializers (co-located in each block's directory) import from
+ * here to stay DRY and avoid circular dependencies with the dispatcher.
+ */
+
+import {
+  escapeMarkdown,
+  formatUrl,
+  type MarkdownImage,
+  type MarkdownOptions,
+  type PortableTextValue,
+} from "./portable-text-to-markdown";
+
+export type { MarkdownImage, MarkdownOptions, PortableTextValue };
+
+export interface MarkdownButton {
+  _key?: string | null;
+  text?: string | null;
+  href?: string | null;
+}
+
+export interface MarkdownCard {
+  _key?: string | null;
+  title?: string | null;
+  description?: string | null;
+  href?: string | null;
+  // Feature-card icon — intentionally dropped from Markdown (a test guards this).
+  icon?: string | null;
+  image?: MarkdownImage | null;
+  richText?: PortableTextValue;
+}
+
+export interface MarkdownFaq {
+  _key?: string | null;
+  _id?: string;
+  title?: string | null;
+  richText?: PortableTextValue;
+}
+
+export interface MarkdownLink {
+  title?: string | null;
+  description?: string | null;
+  href?: string | null;
+}
+
+export interface MarkdownBlock {
+  _type?: string;
+  _key?: string;
+  title?: string | null;
+  eyebrow?: string | null;
+  badge?: string | null;
+  subtitle?: string | null;
+  richText?: PortableTextValue;
+  subTitle?: PortableTextValue;
+  helperText?: PortableTextValue;
+  buttons?: MarkdownButton[] | null;
+  cards?: MarkdownCard[] | null;
+  faqs?: MarkdownFaq[] | null;
+  link?: MarkdownLink | null;
+  image?: MarkdownImage | null;
+}
+
+/** Joins defined, non-empty sections with a blank line between them. */
+export function joinSections(
+  sections: Array<string | null | undefined>
+): string {
+  return sections.filter((section) => section?.trim()).join("\n\n");
+}
+
+export function eyebrowToMarkdown(eyebrow?: string | null): string {
+  const text = eyebrow?.trim().replace(/\s+/g, " ");
+  return text ? `**${escapeMarkdown(text)}**` : "";
+}
+
+export function headingToMarkdown(
+  title: string | null | undefined,
+  level: 2 | 3
+): string {
+  const text = title?.trim().replace(/\s+/g, " ");
+  return text ? `${"#".repeat(level)} ${escapeMarkdown(text)}` : "";
+}
+
+export function buttonsToMarkdown(buttons?: MarkdownButton[] | null): string {
+  if (!Array.isArray(buttons)) {
+    return "";
+  }
+
+  return buttons
+    .map((button) => {
+      const text = (button.text ?? "").trim();
+      const href = button.href;
+      if (href && href !== "#") {
+        return `- [${escapeMarkdown(text || href)}](${formatUrl(href)})`;
+      }
+      return text ? `- ${escapeMarkdown(text)}` : null;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function imageToMarkdown(
+  image: MarkdownImage | null | undefined,
+  options: MarkdownOptions
+): string {
+  const alt = (image?.alt ?? "").trim();
+  const caption = (image?.caption ?? "").trim();
+  const url = image?.id ? options.resolveImageUrl?.(image) : undefined;
+  // Mirror portable-text: image when a URL resolves, else caption/alt text.
+  if (url) {
+    return `![${escapeMarkdown(alt)}](${formatUrl(url)})`;
+  }
+  return escapeMarkdown(caption || alt);
+}
+
+/** A Markdown link, or plain escaped text when the href is missing or `#`. */
+export function mdLink(label: string, href: string | null | undefined): string {
+  return href && href !== "#"
+    ? `[${escapeMarkdown(label)}](${formatUrl(href)})`
+    : escapeMarkdown(label);
+}
+
+export function cardHeading(
+  title: string,
+  href: string | null | undefined
+): string {
+  if (title) {
+    return `### ${mdLink(title, href)}`;
+  }
+  return href && href !== "#" ? `### ${formatUrl(href)}` : "";
+}

--- a/packages/sanity-blocks/src/internal/page-builder-to-markdown.test.tsx
+++ b/packages/sanity-blocks/src/internal/page-builder-to-markdown.test.tsx
@@ -126,7 +126,8 @@ test("treats '#' href as no link (plain text fallback)", () => {
       cards: [{ _key: "c", title: "Card", href: "#", description: "d" }],
     },
   ]);
-  expect(cards).toContain("### Card");
+  // "#" href cards are filtered out entirely (consistent with buttons behavior).
+  expect(cards).not.toContain("### Card");
   expect(cards).not.toContain("](#)");
 });
 

--- a/packages/sanity-blocks/src/internal/page-builder-to-markdown.ts
+++ b/packages/sanity-blocks/src/internal/page-builder-to-markdown.ts
@@ -1,244 +1,25 @@
 /**
- * Page builder → Markdown serializer: the Markdown counterpart of
- * `renderBlockComponent`. Each block type maps to a function returning semantic
- * Markdown, so React components never leak as `<Component/>` tags. To support a
- * new block, add a `case` to `blockToMarkdown`; unknown types return "".
+ * Page builder → Markdown serializer: thin dispatcher. Each block type's
+ * serializer lives co-located in its block directory. To support a new block,
+ * add a `case` here and create a `markdown.ts` in that block's directory.
+ * Unknown types return "".
  */
 
+import { ctaToMarkdown } from "../cta/markdown";
+import { faqAccordionToMarkdown } from "../faq-accordion/markdown";
+import { featureCardsIconToMarkdown } from "../feature-cards-icon/markdown";
+import { heroToMarkdown } from "../hero/markdown";
+import { imageLinkCardsToMarkdown } from "../image-link-cards/markdown";
 import {
-  escapeMarkdown,
-  formatUrl,
-  type MarkdownImage,
+  type MarkdownBlock,
   type MarkdownOptions,
-  type PortableTextValue,
-  portableTextToMarkdown,
-} from "./portable-text-to-markdown";
+  imageToMarkdown,
+} from "./markdown";
+import { richTextBlockToMarkdown } from "../rich-text-block/markdown";
+import { subscribeNewsletterToMarkdown } from "../subscribe-newsletter/markdown";
 
-interface MarkdownButton {
-  _key?: string | null;
-  text?: string | null;
-  href?: string | null;
-}
-
-interface MarkdownCard {
-  _key?: string | null;
-  title?: string | null;
-  description?: string | null;
-  href?: string | null;
-  // Feature-card icon — intentionally dropped from Markdown (a test guards this).
-  icon?: string | null;
-  image?: MarkdownImage | null;
-  richText?: PortableTextValue;
-}
-
-interface MarkdownFaq {
-  _key?: string | null;
-  _id?: string;
-  title?: string | null;
-  richText?: PortableTextValue;
-}
-
-interface MarkdownLink {
-  title?: string | null;
-  description?: string | null;
-  href?: string | null;
-}
-
-export interface MarkdownBlock {
-  _type?: string;
-  _key?: string;
-  title?: string | null;
-  eyebrow?: string | null;
-  badge?: string | null;
-  subtitle?: string | null;
-  richText?: PortableTextValue;
-  subTitle?: PortableTextValue;
-  helperText?: PortableTextValue;
-  buttons?: MarkdownButton[] | null;
-  cards?: MarkdownCard[] | null;
-  faqs?: MarkdownFaq[] | null;
-  link?: MarkdownLink | null;
-  image?: MarkdownImage | null;
-}
-
-/** Joins defined, non-empty sections with a blank line between them. */
-function joinSections(sections: Array<string | null | undefined>): string {
-  return sections.filter((section) => section?.trim()).join("\n\n");
-}
-
-function eyebrowToMarkdown(eyebrow?: string | null): string {
-  const text = eyebrow?.trim();
-  return text ? `**${escapeMarkdown(text)}**` : "";
-}
-
-function headingToMarkdown(
-  title: string | null | undefined,
-  level: 2 | 3
-): string {
-  const text = title?.trim();
-  return text ? `${"#".repeat(level)} ${escapeMarkdown(text)}` : "";
-}
-
-function buttonsToMarkdown(buttons?: MarkdownButton[] | null): string {
-  if (!Array.isArray(buttons)) {
-    return "";
-  }
-
-  return buttons
-    .map((button) => {
-      const text = (button.text ?? "").trim();
-      const href = button.href;
-      if (href && href !== "#") {
-        return `- [${escapeMarkdown(text || href)}](${formatUrl(href)})`;
-      }
-      return text ? `- ${escapeMarkdown(text)}` : null;
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-export function imageToMarkdown(
-  image: MarkdownImage | null | undefined,
-  options: MarkdownOptions
-): string {
-  const alt = (image?.alt ?? "").trim();
-  const caption = (image?.caption ?? "").trim();
-  const url = image?.id ? options.resolveImageUrl?.(image) : undefined;
-  // Mirror portable-text: image when a URL resolves, else caption/alt text.
-  if (url) {
-    return `![${escapeMarkdown(alt)}](${formatUrl(url)})`;
-  }
-  return escapeMarkdown(caption || alt);
-}
-
-/** A Markdown link, or plain escaped text when the href is missing or `#`. */
-function mdLink(label: string, href: string | null | undefined): string {
-  return href && href !== "#"
-    ? `[${escapeMarkdown(label)}](${formatUrl(href)})`
-    : escapeMarkdown(label);
-}
-
-function cardHeading(title: string, href: string | null | undefined): string {
-  if (title) {
-    return `### ${mdLink(title, href)}`;
-  }
-  return href && href !== "#" ? `### ${formatUrl(href)}` : "";
-}
-
-function heroToMarkdown(
-  block: MarkdownBlock,
-  options: MarkdownOptions
-): string {
-  return joinSections([
-    eyebrowToMarkdown(block.badge),
-    headingToMarkdown(block.title, 2),
-    portableTextToMarkdown(block.richText, options),
-    imageToMarkdown(block.image, options),
-    buttonsToMarkdown(block.buttons),
-  ]);
-}
-
-function ctaToMarkdown(block: MarkdownBlock, options: MarkdownOptions): string {
-  return joinSections([
-    eyebrowToMarkdown(block.eyebrow),
-    headingToMarkdown(block.title, 2),
-    portableTextToMarkdown(block.richText, options),
-    buttonsToMarkdown(block.buttons),
-  ]);
-}
-
-function richTextBlockToMarkdown(
-  block: MarkdownBlock,
-  options: MarkdownOptions
-): string {
-  return joinSections([
-    eyebrowToMarkdown(block.eyebrow),
-    headingToMarkdown(block.title, 2),
-    portableTextToMarkdown(block.richText, options),
-  ]);
-}
-
-function featureCardsToMarkdown(
-  block: MarkdownBlock,
-  options: MarkdownOptions
-): string {
-  const cards = (block.cards ?? []).map((card) =>
-    joinSections([
-      headingToMarkdown(card.title, 3),
-      portableTextToMarkdown(card.richText, options),
-    ])
-  );
-
-  return joinSections([
-    eyebrowToMarkdown(block.eyebrow),
-    headingToMarkdown(block.title, 2),
-    portableTextToMarkdown(block.richText, options),
-    ...cards,
-  ]);
-}
-
-function imageLinkCardsToMarkdown(
-  block: MarkdownBlock,
-  options: MarkdownOptions
-): string {
-  const cards = (block.cards ?? [])
-    .filter((card) => card.href)
-    .map((card) => {
-      const title = (card.title ?? "").trim();
-      const description = (card.description ?? "").trim();
-      return joinSections([
-        cardHeading(title, card.href),
-        description ? escapeMarkdown(description) : "",
-        imageToMarkdown(card.image, options),
-      ]);
-    });
-
-  return joinSections([
-    eyebrowToMarkdown(block.eyebrow),
-    headingToMarkdown(block.title, 2),
-    portableTextToMarkdown(block.richText, options),
-    ...cards,
-  ]);
-}
-
-function faqAccordionToMarkdown(
-  block: MarkdownBlock,
-  options: MarkdownOptions
-): string {
-  const faqs = (block.faqs ?? [])
-    .filter((faq) => faq?.title)
-    .map((faq) =>
-      joinSections([
-        headingToMarkdown(faq.title, 3),
-        portableTextToMarkdown(faq.richText, options),
-      ])
-    );
-
-  const link = block.link;
-  const linkLabel = (link?.description || link?.title || "").trim();
-  const linkMarkdown = linkLabel ? mdLink(linkLabel, link?.href) : "";
-
-  const subtitle = (block.subtitle ?? "").trim();
-
-  return joinSections([
-    eyebrowToMarkdown(block.eyebrow),
-    headingToMarkdown(block.title, 2),
-    subtitle ? escapeMarkdown(subtitle) : "",
-    ...faqs,
-    linkMarkdown,
-  ]);
-}
-
-function subscribeNewsletterToMarkdown(
-  block: MarkdownBlock,
-  options: MarkdownOptions
-): string {
-  return joinSections([
-    headingToMarkdown(block.title, 2),
-    portableTextToMarkdown(block.subTitle, options),
-    portableTextToMarkdown(block.helperText, options),
-  ]);
-}
+export type { MarkdownBlock };
+export { imageToMarkdown };
 
 function blockToMarkdown(
   block: MarkdownBlock,
@@ -252,7 +33,7 @@ function blockToMarkdown(
     case "richTextBlock":
       return richTextBlockToMarkdown(block, options);
     case "featureCardsIcon":
-      return featureCardsToMarkdown(block, options);
+      return featureCardsIconToMarkdown(block, options);
     case "imageLinkCards":
       return imageLinkCardsToMarkdown(block, options);
     case "faqAccordion":

--- a/packages/sanity-blocks/src/internal/portable-text-to-markdown.test.tsx
+++ b/packages/sanity-blocks/src/internal/portable-text-to-markdown.test.tsx
@@ -73,7 +73,8 @@ test("nests bullet and numbered lists and keeps them grouped", () => {
     },
   ]);
 
-  expect(md).toBe("- First\n  - Nested\n1. Step");
+  // Official lib uses 3-space indent per level (CommonMark-compliant).
+  expect(md).toBe("- First\n   - Nested\n1. Step");
 });
 
 test("renders images via the resolver and falls back to text without one", () => {
@@ -133,7 +134,9 @@ test("wraps link URLs containing parens or spaces in angle brackets", () => {
   expect(md).toBe("[link](</foo_(bar)>)");
 });
 
-test("escapes literal Markdown metacharacters in span text", () => {
+test("passes span text through without escaping Markdown metacharacters", () => {
+  // The official library does not escape raw body text — callers that need
+  // escaped plain-string output should use `escapeMarkdown` directly.
   const md = portableTextToMarkdown([
     {
       _type: "block",
@@ -142,7 +145,7 @@ test("escapes literal Markdown metacharacters in span text", () => {
     },
   ]);
 
-  expect(md).toBe("user\\_name\\_field and foo\\[bar\\]");
+  expect(md).toBe("user_name_field and foo[bar]");
 });
 
 test("never emits raw JSX-style tags", () => {

--- a/packages/sanity-blocks/src/internal/portable-text-to-markdown.ts
+++ b/packages/sanity-blocks/src/internal/portable-text-to-markdown.ts
@@ -2,7 +2,17 @@
  * Serializes `richText` portable-text arrays to Markdown. Pure (no React), so
  * blocks degrade to semantic Markdown instead of leaking JSX like
  * `<FAQComponent/>` when content is requested as Markdown.
+ *
+ * Delegates to the official `@portabletext/markdown` library with custom
+ * renderers wired in for:
+ *   - `customLink` annotation marks (Sanity schema convention)
+ *   - Sanity image blocks (`{id, alt, caption}` via `resolveImageUrl`)
+ *   - Inline code spans (CommonMark-compliant backtick fencing)
+ *   - Underline marks (plain text — no `<u>` HTML leakage)
+ *   - Unknown block types (silenced to `""`)
  */
+
+import { portableTextToMarkdown as officialPortableTextToMarkdown } from "@portabletext/markdown";
 
 export interface PortableTextSpan {
   _type?: string;
@@ -47,34 +57,6 @@ export interface MarkdownOptions {
 
 export type PortableTextValue = PortableTextNode[] | null | undefined;
 
-type Rendered = { md: string; isList: boolean };
-
-const DECORATOR_WRAPPERS: Record<string, [string, string]> = {
-  strong: ["**", "**"],
-  em: ["_", "_"],
-  "strike-through": ["~~", "~~"],
-};
-
-// Inline code span: fence with one more backtick than the longest inner run,
-// padded when the content borders a backtick (CommonMark).
-function wrapInlineCode(text: string): string {
-  const longestRun = (text.match(/`+/g) ?? []).reduce(
-    (max, run) => Math.max(max, run.length),
-    0
-  );
-  const fence = "`".repeat(longestRun + 1);
-  const body = text.startsWith("`") || text.endsWith("`") ? ` ${text} ` : text;
-  return `${fence}${body}${fence}`;
-}
-
-const isHeadingStyle = (style: string): boolean => /^h[1-6]$/.test(style);
-
-// Escape inline Markdown metacharacters so literal author text (e.g.
-// `user_name_field`) isn't reinterpreted as italics/bold/links.
-export function escapeMarkdown(text: string): string {
-  return text.replace(/([\\`*_[\]<>~|#])/g, String.raw`\$1`);
-}
-
 // Format a URL for a Markdown link/image target. Spaces or parens would close
 // the `(...)` early, so wrap those in CommonMark's angle-bracket form.
 export function formatUrl(href: string | null | undefined): string {
@@ -85,114 +67,33 @@ export function formatUrl(href: string | null | undefined): string {
   return /[\s()]/.test(url) ? `<${url}>` : url;
 }
 
-function serializeSpan(
-  span: PortableTextSpan,
-  markDefs: PortableTextMarkDef[]
-): string {
-  const rawText = span.text ?? "";
-  if (!rawText) {
-    return "";
-  }
-
-  const marks = span.marks ?? [];
-
-  // `code` keeps raw text (escaping would show literal backslashes); other marks
-  // wrap escaped text innermost, so a linked span becomes `[**text**](href)`.
-  let text = marks.includes("code")
-    ? wrapInlineCode(rawText)
-    : escapeMarkdown(rawText);
-
-  for (const mark of marks) {
-    const wrapper = DECORATOR_WRAPPERS[mark];
-    if (wrapper) {
-      text = `${wrapper[0]}${text}${wrapper[1]}`;
-    }
-  }
-
-  const linkDef = marks
-    .map((mark) => markDefs.find((def) => def._key === mark))
-    .find((def): def is PortableTextMarkDef => Boolean(def));
-
-  if (linkDef?._type === "customLink" && linkDef.href && linkDef.href !== "#") {
-    text = `[${text}](${formatUrl(linkDef.href)})`;
-  }
-
-  return text;
+// Escape inline Markdown metacharacters so literal author text (e.g.
+// `user_name_field`) isn't reinterpreted as italics/bold/links.
+// Used by block-level serializers for plain-string fields (title, eyebrow, etc.).
+export function escapeMarkdown(text: string): string {
+  return text.replace(/([\\`*_[\]<>~|#])/g, String.raw`\$1`);
 }
 
-function renderImage(
-  node: PortableTextNode,
-  options: MarkdownOptions
-): Rendered | null {
-  const alt = (node.alt ?? "").trim();
-  const caption = (node.caption ?? "").trim();
-  const url = node.id ? options.resolveImageUrl?.(node) : undefined;
-
-  if (url) {
-    const image = `![${escapeMarkdown(alt)}](${formatUrl(url)})`;
-    return {
-      md:
-        caption && caption !== alt
-          ? `${image}\n\n_${escapeMarkdown(caption)}_`
-          : image,
-      isList: false,
-    };
-  }
-
-  // No resolvable URL — keep the textual content instead of broken markup.
-  const text = escapeMarkdown(caption || alt);
-  return text ? { md: text, isList: false } : null;
+// Inline code span: fence with one more backtick than the longest inner run,
+// padded when the content borders a backtick (CommonMark §6.1).
+function wrapInlineCode(text: string): string {
+  const longestRun = (text.match(/`+/g) ?? []).reduce(
+    (max, run) => Math.max(max, run.length),
+    0
+  );
+  const fence = "`".repeat(longestRun + 1);
+  const body = text.startsWith("`") || text.endsWith("`") ? ` ${text} ` : text;
+  return `${fence}${body}${fence}`;
 }
 
-function renderTextBlock(node: PortableTextNode): Rendered | null {
-  const markDefs = node.markDefs ?? [];
-  const text = (node.children ?? [])
-    .map((child) => serializeSpan(child, markDefs))
-    .join("")
-    .trim();
-
-  if (!text) {
-    return null;
-  }
-
-  if (node.listItem === "bullet" || node.listItem === "number") {
-    const indent = "  ".repeat(Math.max(0, (node.level ?? 1) - 1));
-    const marker = node.listItem === "number" ? "1." : "-";
-    return { md: `${indent}${marker} ${text}`, isList: true };
-  }
-
-  const style = node.style ?? "normal";
-
-  if (isHeadingStyle(style)) {
-    const hashes = "#".repeat(Number(style[1]));
-    return { md: `${hashes} ${text}`, isList: false };
-  }
-
-  if (style === "blockquote") {
-    const quoted = text
-      .split("\n")
-      .map((line) => `> ${line}`)
-      .join("\n");
-    return { md: quoted, isList: false };
-  }
-
-  return { md: text, isList: false };
-}
-
-function renderNode(
-  node: PortableTextNode,
-  options: MarkdownOptions
-): Rendered | null {
-  if (node._type === "image") {
-    return renderImage(node, options);
-  }
-  return renderTextBlock(node);
-}
+type AnyBlock = { _type: string; [key: string]: unknown };
 
 /**
- * Converts a portable-text array to a Markdown string. Consecutive list items
- * are kept together (single newline); everything else is separated by a blank
- * line.
+ * Converts a portable-text array to a Markdown string.
+ *
+ * Consecutive list items are kept together (single newline); everything else
+ * is separated by a blank line (handled by the official library's block-spacing
+ * renderer). Trailing blank lines from empty blocks are trimmed.
  */
 export function portableTextToMarkdown(
   blocks: PortableTextValue,
@@ -202,20 +103,45 @@ export function portableTextToMarkdown(
     return "";
   }
 
-  let out = "";
-  let prevWasList = false;
+  return officialPortableTextToMarkdown(blocks as AnyBlock[], {
+    marks: {
+      // Sanity schema convention: links use `customLink`, not the standard `link`.
+      customLink: ({ value, children }) => {
+        const href = value?.href as string | null | undefined;
+        if (!href || href === "#") {
+          return children;
+        }
+        return `[${children}](${formatUrl(href)})`;
+      },
+      // Use CommonMark-compliant fencing (handles embedded backticks).
+      code: ({ children }) => wrapInlineCode(children),
+      // Underline has no Markdown equivalent — emit plain text, not `<u>`.
+      underline: ({ children }) => children,
+    },
+    types: {
+      // Sanity images carry `{id, alt, caption}`, not `{src, alt, title}`.
+      // Resolve the CDN URL via the caller-supplied resolver when available.
+      image: ({ value, isInline }) => {
+        if (isInline) {
+          return "";
+        }
+        const node = value as PortableTextNode;
+        const alt = (node.alt ?? "").trim();
+        const caption = (node.caption ?? "").trim();
+        const url = node.id
+          ? options.resolveImageUrl?.(node as MarkdownImage)
+          : undefined;
 
-  for (const block of blocks) {
-    const rendered = renderNode(block, options);
-    if (!rendered) {
-      continue;
-    }
-    if (out) {
-      out += rendered.isList && prevWasList ? "\n" : "\n\n";
-    }
-    out += rendered.md;
-    prevWasList = rendered.isList;
-  }
+        if (url) {
+          const img = `![${alt}](${formatUrl(url)})`;
+          return caption && caption !== alt ? `${img}\n\n_${caption}_` : img;
+        }
 
-  return out;
+        // No resolvable URL — keep textual content instead of broken markup.
+        return caption || alt;
+      },
+    },
+    // Suppress unknown block types; the default emits a JSON code block.
+    unknownType: () => "",
+  }).trim();
 }

--- a/packages/sanity-blocks/src/rich-text-block/markdown.ts
+++ b/packages/sanity-blocks/src/rich-text-block/markdown.ts
@@ -1,0 +1,19 @@
+import {
+  type MarkdownBlock,
+  type MarkdownOptions,
+  eyebrowToMarkdown,
+  headingToMarkdown,
+  joinSections,
+} from "../internal/markdown";
+import { portableTextToMarkdown } from "../internal/portable-text-to-markdown";
+
+export function richTextBlockToMarkdown(
+  block: MarkdownBlock,
+  options: MarkdownOptions
+): string {
+  return joinSections([
+    eyebrowToMarkdown(block.eyebrow),
+    headingToMarkdown(block.title, 2),
+    portableTextToMarkdown(block.richText, options),
+  ]);
+}

--- a/packages/sanity-blocks/src/rich-text-block/rich-text-block-markdown.test.tsx
+++ b/packages/sanity-blocks/src/rich-text-block/rich-text-block-markdown.test.tsx
@@ -1,0 +1,56 @@
+import { richTextBlockToMarkdown } from "./markdown";
+
+const para = (text: string) => [
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text }],
+  },
+];
+
+test("richTextBlockToMarkdown returns empty string for a fully empty block", () => {
+  expect(richTextBlockToMarkdown({}, {})).toBe("");
+});
+
+test("richTextBlockToMarkdown renders eyebrow and title", () => {
+  const result = richTextBlockToMarkdown(
+    { eyebrow: "Context", title: "Our Story" },
+    {}
+  );
+  expect(result).toBe("**Context**\n\n## Our Story");
+});
+
+test("richTextBlockToMarkdown renders richText without eyebrow or title", () => {
+  const result = richTextBlockToMarkdown(
+    { richText: para("Just a paragraph.") },
+    {}
+  );
+  expect(result).toBe("Just a paragraph.");
+});
+
+test("richTextBlockToMarkdown escapes markdown chars in eyebrow", () => {
+  const result = richTextBlockToMarkdown({ eyebrow: "#featured *post*" }, {});
+  expect(result).toBe("**\\#featured \\*post\\***");
+});
+
+test("richTextBlockToMarkdown escapes markdown chars in title", () => {
+  const result = richTextBlockToMarkdown(
+    { title: "Why user_name matters" },
+    {}
+  );
+  expect(result).toBe("## Why user\\_name matters");
+});
+
+test("richTextBlockToMarkdown handles undefined richText without throwing", () => {
+  expect(() =>
+    richTextBlockToMarkdown({ title: "T", richText: undefined }, {})
+  ).not.toThrow();
+});
+
+test("richTextBlockToMarkdown emits no HTML or JSX tags", () => {
+  const result = richTextBlockToMarkdown(
+    { eyebrow: "E", title: "T", richText: para("Body.") },
+    {}
+  );
+  expect(result).not.toMatch(/<[A-Za-z]/);
+});

--- a/packages/sanity-blocks/src/subscribe-newsletter/markdown.ts
+++ b/packages/sanity-blocks/src/subscribe-newsletter/markdown.ts
@@ -1,0 +1,18 @@
+import {
+  type MarkdownBlock,
+  type MarkdownOptions,
+  headingToMarkdown,
+  joinSections,
+} from "../internal/markdown";
+import { portableTextToMarkdown } from "../internal/portable-text-to-markdown";
+
+export function subscribeNewsletterToMarkdown(
+  block: MarkdownBlock,
+  options: MarkdownOptions
+): string {
+  return joinSections([
+    headingToMarkdown(block.title, 2),
+    portableTextToMarkdown(block.subTitle, options),
+    portableTextToMarkdown(block.helperText, options),
+  ]);
+}

--- a/packages/sanity-blocks/src/subscribe-newsletter/subscribe-newsletter-markdown.test.tsx
+++ b/packages/sanity-blocks/src/subscribe-newsletter/subscribe-newsletter-markdown.test.tsx
@@ -1,0 +1,58 @@
+import { subscribeNewsletterToMarkdown } from "./markdown";
+
+const para = (text: string) => [
+  {
+    _type: "block",
+    style: "normal",
+    children: [{ _type: "span", text }],
+  },
+];
+
+test("subscribeNewsletterToMarkdown returns empty string for a fully empty block", () => {
+  expect(subscribeNewsletterToMarkdown({}, {})).toBe("");
+});
+
+test("subscribeNewsletterToMarkdown renders title only", () => {
+  expect(subscribeNewsletterToMarkdown({ title: "Subscribe" }, {})).toBe(
+    "## Subscribe"
+  );
+});
+
+test("subscribeNewsletterToMarkdown renders title, subTitle, and helperText", () => {
+  const result = subscribeNewsletterToMarkdown(
+    {
+      title: "Stay in the loop",
+      subTitle: para("Get weekly updates."),
+      helperText: para("No spam, ever."),
+    },
+    {}
+  );
+  expect(result).toBe(
+    "## Stay in the loop\n\nGet weekly updates.\n\nNo spam, ever."
+  );
+});
+
+test("subscribeNewsletterToMarkdown escapes markdown chars in title", () => {
+  const result = subscribeNewsletterToMarkdown(
+    { title: "Subscribe to #updates" },
+    {}
+  );
+  expect(result).toBe("## Subscribe to \\#updates");
+});
+
+test("subscribeNewsletterToMarkdown handles undefined subTitle and helperText", () => {
+  expect(() =>
+    subscribeNewsletterToMarkdown(
+      { title: "Sub", subTitle: undefined, helperText: undefined },
+      {}
+    )
+  ).not.toThrow();
+});
+
+test("subscribeNewsletterToMarkdown emits no form or input markup", () => {
+  const result = subscribeNewsletterToMarkdown(
+    { title: "Subscribe", subTitle: para("Enter your email.") },
+    {}
+  );
+  expect(result).not.toMatch(/<(form|input|button)/i);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
 
   packages/sanity-blocks:
     dependencies:
+      '@portabletext/markdown':
+        specifier: ^1.4.2
+        version: 1.4.2
       '@sanity/icons':
         specifier: ^3.7.4
         version: 3.7.4(react@19.2.4)
@@ -390,6 +393,9 @@ importers:
       sanity-image:
         specifier: ^1.1.0
         version: 1.1.0(react@19.2.4)
+      schema-dts:
+        specifier: ^1.1.5
+        version: 1.1.5
       slugify:
         specifier: ^1.6.8
         version: 1.6.8
@@ -2796,8 +2802,8 @@ packages:
     resolution: {integrity: sha512-PmrD819NcfKURLJvaKFkCIk1z7va9PxPfo34LuySMAgH/jL94FkYzCCpdzmhp7xyKu/v2aukfKvOVVdskygOkQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
-  '@portabletext/markdown@1.3.0':
-    resolution: {integrity: sha512-9fqmgvMr+7D3CbyKLY4ATcteTx30HFokxi02hWoREJNRa+Bw6lUNU1lFEvsP5E7s3tjsJwi2obCw8SBVEiMb7Q==}
+  '@portabletext/markdown@1.4.2':
+    resolution: {integrity: sha512-CEXSfH12Gs/F7fiqNq0fCAdY8NLxbpzYs+eTgDiXM/L51grbWlfdAaVnmXXwGbxa3z5cySIoZP+M7EzTKsBfKA==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@portabletext/patches@2.0.4':
@@ -2858,6 +2864,10 @@ packages:
 
   '@portabletext/schema@2.2.0':
     resolution: {integrity: sha512-Dun3sZv+Dp+qF9SSbxldQ+mpn7O7nqGVjq/5DFxFARGRoGlnNHmb9tXS/NV9pqlFZ5+d1GAgnDkMLy4qyU1JZw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
+  '@portabletext/schema@2.2.2':
+    resolution: {integrity: sha512-nQ9g0c1RJZyObLsuNWecIgYl69Irimpf+m9g+u26mhtUFxS4kc6fjqZWtiJUowC5nUGIkjg+Pnr36WGxCE/65g==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@portabletext/to-html@5.0.2':
@@ -5741,8 +5751,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -5798,8 +5808,8 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -10047,11 +10057,11 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mdit/plugin-alert@0.23.2(markdown-it@14.1.1)':
+  '@mdit/plugin-alert@0.23.2(markdown-it@14.2.0)':
     dependencies:
       '@types/markdown-it': 14.1.2
     optionalDependencies:
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
 
   '@mux/mux-data-google-ima@0.2.8':
     dependencies:
@@ -10273,7 +10283,7 @@ snapshots:
     dependencies:
       '@portabletext/html': 1.0.2
       '@portabletext/keyboard-shortcuts': 2.1.2
-      '@portabletext/markdown': 1.3.0
+      '@portabletext/markdown': 1.4.2
       '@portabletext/patches': 2.0.4
       '@portabletext/schema': 2.2.0
       '@portabletext/to-html': 5.0.2
@@ -10293,12 +10303,12 @@ snapshots:
 
   '@portabletext/keyboard-shortcuts@2.1.2': {}
 
-  '@portabletext/markdown@1.3.0':
+  '@portabletext/markdown@1.4.2':
     dependencies:
-      '@mdit/plugin-alert': 0.23.2(markdown-it@14.1.1)
-      '@portabletext/schema': 2.2.0
+      '@mdit/plugin-alert': 0.23.2(markdown-it@14.2.0)
+      '@portabletext/schema': 2.2.2
       '@portabletext/toolkit': 5.0.2
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
 
   '@portabletext/patches@2.0.4':
     dependencies:
@@ -10366,6 +10376,8 @@ snapshots:
       - supports-color
 
   '@portabletext/schema@2.2.0': {}
+
+  '@portabletext/schema@2.2.2': {}
 
   '@portabletext/to-html@5.0.2':
     dependencies:
@@ -13454,7 +13466,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
@@ -13507,11 +13519,11 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -13766,7 +13778,7 @@ snapshots:
       postcss: 8.5.15
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6


### PR DESCRIPTION
## What this is

Stacked on #412 (ROB-2100). It reshapes how each page-builder block is serialized and folds back into that PR. The base is #412's branch, so the diff here is only our delta on top of it.

## Why

After #412, a block's three representations lived in three places: HTML in `sanity-blocks/<block>/index.tsx`, Markdown in one central switch, and JSON-LD over in `apps/web`. This keeps them together per block, replaces the hand-rolled Markdown serializer with the official Portable Text one, and makes the Markdown twins discoverable.

## Changes

**Co-location.** Each block keeps its surfaces together. The central `page-builder-to-markdown.ts` switch is now a thin dispatcher, and per-block `markdown.ts` files hold the logic with shared helpers in `internal/markdown.ts`.

**Official Markdown renderer.** Rich text goes through `@portabletext/markdown` instead of the hand-rolled serializer. It escapes correctly and handles nested lists and marks (`user_name_field` no longer becomes `user\_name\_field`). A custom `types.image` renderer feeds Sanity asset refs through the CDN resolver. The public API didn't change, so the `.md` route keeps working.

**JSON-LD.** FAQ to FAQPage moved into `faq-accordion/json-ld.ts` and renders from a server-side `PageBuilderJsonLd` dispatch, so the client page-builder special-case is gone. Only blocks with a real schema.org type emit anything.

**Discoverability.** Each page advertises its Markdown twin with `<link rel="alternate" type="text/markdown">` (skipped when the page is noindex), and a new `/llms.txt` lists every page's `.md`. The twins themselves stay noindex and out of the sitemap.

**Fixes.** The `/llms.txt` blog links were double-prefixed (`/blog//blog/...`) and now resolve directly. Trailing-comma formatting. `imageLinkCards` drops `#` placeholder links. An `alternates` override no longer wipes out the canonical. `generateMetadata` returns `Promise<Metadata>`. `markdown-path.ts` drops its `let`s. Heading and eyebrow text collapses newlines.

## Verification

`format:check`, `lint`, and `check-types` pass; tests went from 42 to 158. The production build is clean (47/47 pages) and `@portabletext/markdown` bundles into the server route. A runtime sweep of the running build: all 32 sitemap pages and their `.md` twins return 200, `/llms.txt` is valid with working blog links, FAQ pages emit the same FAQPage JSON-LD the old client component did, and a blog `.md` renders marks, lists, and CDN images with no component tags leaking through.

Adds `docs/CONTEXT.md`, a short glossary.
