### PR TITLE
Pixelate sanity-image LQIP placeholder instead of blur

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -136,6 +136,12 @@ img {
   border-radius: var(--radius-md);
 }
 
+/* Render the `sanity-image` LQIP placeholder as crisp pixel blocks
+   (nearest-neighbor upscale) so images load in pixelated rather than blurred. */
+img[data-lqip] {
+  image-rendering: pixelated;
+}
+
 /* FAQ disclosure: smooth open/close, instant fallback where unsupported. */
 @media (prefers-reduced-motion: no-preference) {
   .faq-disclosure {


### PR DESCRIPTION
## Problem / Intent

Sanity images loaded with a **blur-up** placeholder: the `sanity-image` library renders the tiny LQIP (`asset->metadata.lqip`, ~20px) as an `<img data-lqip>` scaled to full size, which the browser upscales smoothly into a blur. The ticket (ROB-2105) asks for a **pixelated** pre-load instead — the crisp pixel-block look — across `SanityImage` usage in `apps/web`.

## Summary

- Image placeholders now load **pixelated** (hard pixel blocks) instead of blurred, by switching the LQIP placeholder's upscaling from smooth to nearest-neighbor. This is a one-line CSS rule — no query, type, or component changes.
- Applies uniformly to every `SanityImage` that has a `preview` (hero, blog cards, and all other usages), since they all share the library's `data-lqip` placeholder element. The hero already fetches and passes `preview`, so it's covered automatically.
- No layout shift or extra requests: the LQIP is already fetched and the placeholder already reserves its aspect ratio — only the rendering mode of the existing element changes.

## Core file changes

| File | Change |
| --- | --- |
| `packages/ui/src/styles/globals.css` | Add `img[data-lqip] { image-rendering: pixelated; }` so the `sanity-image` LQIP placeholder upscales nearest-neighbor (pixelated) rather than smooth (blur). |

## Preview

**Homepage**

<img width="1303" height="924" alt="image" src="https://github.com/user-attachments/assets/148e59fa-d214-4335-ac36-1a1ef58e7c8d" />

**Blog**

<img width="1303" height="924" alt="image" src="https://github.com/user-attachments/assets/3723f1a4-987a-4ea8-bfa5-5cdc165ce186" />


## Verification

- [x] `pnpm format:check` (Biome) — formatting clean
- [x] `pnpm lint`
- [x] Open `/blog`, throttle the network (DevTools → Slow 3G), hard-refresh: the lazy-loaded card placeholders render as crisp pixel blocks (not blurred) and swap to the full image with no reflow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading placeholders for images so low-quality previews now appear as crisp pixelated blocks instead of blurred placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->