### PR TITLE
chore: bind repo to roboto-mem team memory

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "roboto-mem": {
+      "source": {
+        "source": "github",
+        "repo": "robotostudio/roboto-mem"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "roboto-mem@roboto-mem": true
+  }
+}

--- a/.roboto-mem.json
+++ b/.roboto-mem.json
@@ -1,0 +1,46 @@
+{
+  "configVersion": 1,
+  "commons": "https://github.com/robotostudio/team-memory",
+  "overlays": [],
+  "project": "turbo-start-sanity",
+  "squads": [],
+  "workspaces": {
+    "packages/sanity-blocks": [
+      "stack/nextjs",
+      "stack/sanity",
+      "stack/typescript"
+    ],
+    "packages/sanity": [
+      "stack/nextjs",
+      "stack/sanity",
+      "stack/typescript"
+    ],
+    "apps/studio": [
+      "stack/react",
+      "stack/sanity",
+      "stack/typescript"
+    ],
+    "packages/env": [
+      "stack/typescript"
+    ],
+    "packages/logger": [
+      "stack/typescript"
+    ],
+    "packages/tailwind-config": [
+      "stack/typescript"
+    ],
+    "apps/web": [
+      "stack/nextjs",
+      "stack/react",
+      "stack/sanity",
+      "stack/typescript"
+    ],
+    "packages/ui": [
+      "stack/react",
+      "stack/typescript"
+    ],
+    ".": [
+      "stack/typescript"
+    ]
+  }
+}


### PR DESCRIPTION
Binds this repo to the team Commons at [robotostudio/team-memory](https://github.com/robotostudio/team-memory) so the Team Memory digest is injected at session start.

## What this adds

- **`.roboto-mem.json`** — the binding: commons URL, project id `turbo-start-sanity`, and the per-workspace stack detection (all 9 workspaces resolved, e.g. `apps/web` → nextjs/react/sanity/typescript, `packages/logger` → typescript). No squads: the Commons has none defined yet.
- **`.claude/settings.json`** — registers the plugin marketplace and enables `roboto-mem@roboto-mem`, so teammates are prompted to install when they trust the folder.

## Resulting session scopes

`org`, `stack/nextjs`, `stack/react`, `stack/sanity`, `stack/typescript`, `project/turbo-start-sanity` — currently resolving to 21 standards and 2 lessons in the digest.

## For teammates after merge

Restart Claude Code, then `/plugin` → enable `roboto-mem@roboto-mem`. The CLI alone is `npx roboto-mem` (verified against v0.3.0).

## Note

The Commons currently reports 35 parse errors, all under `entries/skills/` (missing frontmatter / unknown scope dirs). They don't affect standards or lessons — worth a separate fix upstream in team-memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project configuration for the Roboto Mem development memory plugin.
  * Configured workspace mappings and stack requirements across the project.
  * Registered the shared team-memory repository and project identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->