### PR TITLE
Fix projected data during optimistic page builder updates

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "check-types": "tsc --noEmit",
+    "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },
@@ -49,6 +50,7 @@
     "@types/react-dom": "catalog:",
     "@workspace/typescript-config": "workspace:*",
     "baseline-browser-mapping": "^2.10.8",
-    "dotenv": "^17.3.1"
+    "dotenv": "^17.3.1",
+    "vitest": "catalog:"
   }
 }

--- a/apps/web/src/components/page-builder-optimistic.test.ts
+++ b/apps/web/src/components/page-builder-optimistic.test.ts
@@ -96,6 +96,12 @@ describe("reconcilePageBuilder", () => {
             href: "/contact/",
             openInNewTab: false,
             text: "Contact us",
+            url: {
+              _type: "customUrl",
+              internal: undefined,
+              openInNewTab: false,
+              type: "internal",
+            },
             variant: "outline",
           },
         ],
@@ -386,6 +392,11 @@ describe("reconcilePageBuilder", () => {
         href: "https://example.com",
         openInNewTab: true,
         text: "External",
+        url: {
+          external: "https://example.com",
+          openInNewTab: true,
+          type: "external",
+        },
       },
     ]);
     expect(resultBlock(reconciled, 0).cards).toMatchObject([
@@ -508,5 +519,39 @@ describe("reconcilePageBuilder", () => {
       expect(Object.hasOwn(target, "prototype")).toBe(false);
     }
     expect(image).toEqual({ id: "image-safe-800x600-jpg" });
+  });
+
+  test("preserves defined custom button fields from raw payloads", () => {
+    const rawBlocks = JSON.parse(`[
+      {
+        "_key": "cta",
+        "_type": "cta",
+        "buttons": [
+          {
+            "_key": "contact",
+            "_type": "button",
+            "analyticsId": "contact-primary",
+            "text": "Contact us",
+            "url": {
+              "external": "https://example.com/contact",
+              "type": "external"
+            }
+          }
+        ]
+      }
+    ]`);
+
+    const reconciled = reconcilePageBuilder([], rawBlocks);
+
+    expect(resultBlock(reconciled, 0).buttons).toMatchObject([
+      {
+        _key: "contact",
+        _type: "button",
+        analyticsId: "contact-primary",
+        href: "https://example.com/contact",
+        openInNewTab: false,
+        text: "Contact us",
+      },
+    ]);
   });
 });

--- a/apps/web/src/components/page-builder-optimistic.test.ts
+++ b/apps/web/src/components/page-builder-optimistic.test.ts
@@ -478,4 +478,35 @@ describe("reconcilePageBuilder", () => {
       },
     ]);
   });
+
+  test("ignores unsafe keys in raw blocks and images", () => {
+    const rawBlocks = JSON.parse(`[
+      {
+        "_key": "hero",
+        "_type": "hero",
+        "__proto__": { "polluted": true },
+        "constructor": { "polluted": true },
+        "prototype": { "polluted": true },
+        "image": {
+          "_type": "image",
+          "asset": { "_ref": "image-safe-800x600-jpg" },
+          "__proto__": { "polluted": true },
+          "constructor": { "polluted": true },
+          "prototype": { "polluted": true }
+        }
+      }
+    ]`);
+
+    const reconciled = reconcilePageBuilder([], rawBlocks);
+    const block = resultBlock(reconciled, 0);
+    const image = block.image as Record<string, unknown>;
+
+    for (const target of [block, image]) {
+      expect(Object.getPrototypeOf(target)).toBe(Object.prototype);
+      expect(Object.hasOwn(target, "__proto__")).toBe(false);
+      expect(Object.hasOwn(target, "constructor")).toBe(false);
+      expect(Object.hasOwn(target, "prototype")).toBe(false);
+    }
+    expect(image).toEqual({ id: "image-safe-800x600-jpg" });
+  });
 });

--- a/apps/web/src/components/page-builder-optimistic.test.ts
+++ b/apps/web/src/components/page-builder-optimistic.test.ts
@@ -1,0 +1,481 @@
+import { describe, expect, test } from "vitest";
+
+import type { PageBuilderBlock } from "@/types";
+import { reconcilePageBuilder } from "./page-builder-optimistic";
+
+function projectedBlocks(
+  blocks: Array<Record<string, unknown>>
+): PageBuilderBlock[] {
+  return blocks as unknown as PageBuilderBlock[];
+}
+
+function resultBlock(blocks: PageBuilderBlock[], index: number) {
+  return blocks[index] as unknown as Record<string, unknown>;
+}
+
+describe("reconcilePageBuilder", () => {
+  test("applies raw ordering and edits without breaking projected images or buttons", () => {
+    const current = projectedBlocks([
+      {
+        _key: "hero",
+        _type: "hero",
+        buttons: [
+          {
+            _key: "contact",
+            _type: "button",
+            href: "/contact/",
+            openInNewTab: false,
+            text: "Schedule a call",
+            variant: "default",
+          },
+        ],
+        image: {
+          alt: "A family outside their home",
+          id: "image-family-1200x900-jpg",
+          preview: "data:image/jpeg;base64,preview",
+        },
+        title: "Original title",
+      },
+      {
+        _key: "copy",
+        _type: "richTextBlock",
+        richText: [],
+        title: "Supporting copy",
+      },
+    ]);
+
+    const reconciled = reconcilePageBuilder(current, [
+      {
+        _key: "copy",
+        _type: "richTextBlock",
+        richText: [],
+        title: "Supporting copy",
+      },
+      {
+        _key: "hero",
+        _type: "hero",
+        buttons: [
+          {
+            _key: "contact",
+            _type: "button",
+            text: "Contact us",
+            url: {
+              _type: "customUrl",
+              internal: { _ref: "contact-page", _type: "reference" },
+              openInNewTab: false,
+              type: "internal",
+            },
+            variant: "outline",
+          },
+        ],
+        image: {
+          _type: "image",
+          asset: {
+            _ref: "image-family-1200x900-jpg",
+            _type: "reference",
+          },
+        },
+        title: "Updated title",
+      },
+    ]);
+
+    expect(reconciled).toEqual([
+      {
+        _key: "copy",
+        _type: "richTextBlock",
+        richText: [],
+        title: "Supporting copy",
+      },
+      {
+        _key: "hero",
+        _type: "hero",
+        buttons: [
+          {
+            _key: "contact",
+            _type: "button",
+            href: "/contact/",
+            openInNewTab: false,
+            text: "Contact us",
+            variant: "outline",
+          },
+        ],
+        image: {
+          alt: "A family outside their home",
+          id: "image-family-1200x900-jpg",
+          preview: "data:image/jpeg;base64,preview",
+        },
+        title: "Updated title",
+      },
+    ]);
+  });
+
+  test("applies explicit field and block deletions", () => {
+    const current = projectedBlocks([
+      {
+        _key: "hero",
+        _type: "hero",
+        image: { id: "image-old-800x600-jpg", preview: "old-preview" },
+        title: "Keep this block",
+      },
+      {
+        _key: "removed",
+        _type: "richTextBlock",
+        richText: [],
+        title: "Remove this block",
+      },
+    ]);
+
+    const reconciled = reconcilePageBuilder(current, [
+      {
+        _key: "hero",
+        _type: "hero",
+        title: "Keep this block",
+      },
+    ]);
+
+    expect(reconciled).toEqual([
+      {
+        _key: "hero",
+        _type: "hero",
+        title: "Keep this block",
+      },
+    ]);
+  });
+
+  test("normalizes a new image without carrying metadata from the old asset", () => {
+    const current = projectedBlocks([
+      {
+        _key: "hero",
+        _type: "hero",
+        image: {
+          alt: "Old image",
+          id: "image-old-800x600-jpg",
+          preview: "old-preview",
+        },
+      },
+    ]);
+
+    const reconciled = reconcilePageBuilder(current, [
+      {
+        _key: "hero",
+        _type: "hero",
+        image: {
+          _type: "image",
+          alt: "New image",
+          asset: {
+            _ref: "image-new-1200x900-webp",
+            _type: "reference",
+          },
+          hotspot: { x: 0.4, y: 0.6 },
+        },
+      },
+    ]);
+
+    expect(resultBlock(reconciled, 0).image).toEqual({
+      alt: "New image",
+      hotspot: { x: 0.4, y: 0.6 },
+      id: "image-new-1200x900-webp",
+    });
+  });
+
+  test("preserves projected links and images inside Portable Text", () => {
+    const current = projectedBlocks([
+      {
+        _key: "copy",
+        _type: "richTextBlock",
+        richText: [
+          {
+            _key: "paragraph",
+            _type: "block",
+            children: [
+              {
+                _key: "span",
+                _type: "span",
+                marks: ["learn-more"],
+                text: "Learn more",
+              },
+            ],
+            markDefs: [
+              {
+                _key: "learn-more",
+                _type: "customLink",
+                customLink: {
+                  internal: { _ref: "learn-more-page" },
+                  openInNewTab: false,
+                  type: "internal",
+                },
+                href: "/learn-more/",
+                openInNewTab: false,
+              },
+            ],
+          },
+          {
+            _key: "inline-image",
+            _type: "image",
+            alt: "A house",
+            id: "image-house-900x600-jpg",
+            preview: "house-preview",
+          },
+        ],
+      },
+    ]);
+
+    const reconciled = reconcilePageBuilder(current, [
+      {
+        _key: "copy",
+        _type: "richTextBlock",
+        richText: [
+          {
+            _key: "paragraph",
+            _type: "block",
+            children: [
+              {
+                _key: "span",
+                _type: "span",
+                marks: ["learn-more"],
+                text: "Read the details",
+              },
+            ],
+            markDefs: [
+              {
+                _key: "learn-more",
+                _type: "customLink",
+                customLink: {
+                  _type: "customUrl",
+                  internal: {
+                    _ref: "learn-more-page",
+                    _type: "reference",
+                  },
+                  openInNewTab: false,
+                  type: "internal",
+                },
+              },
+            ],
+          },
+          {
+            _key: "inline-image",
+            _type: "image",
+            asset: {
+              _ref: "image-house-900x600-jpg",
+              _type: "reference",
+            },
+          },
+        ],
+      },
+    ]);
+
+    const richText = resultBlock(reconciled, 0).richText as Array<
+      Record<string, unknown>
+    >;
+    expect(richText[0]).toMatchObject({
+      children: [{ text: "Read the details" }],
+      markDefs: [
+        {
+          href: "/learn-more/",
+          openInNewTab: false,
+        },
+      ],
+    });
+    expect(richText[1]).toEqual({
+      _key: "inline-image",
+      _type: "image",
+      alt: "A house",
+      id: "image-house-900x600-jpg",
+      preview: "house-preview",
+    });
+  });
+
+  test("reorders resolved FAQ references and omits newly unresolved references", () => {
+    const current = projectedBlocks([
+      {
+        _key: "faqs",
+        _type: "faqAccordion",
+        faqs: [
+          { _id: "faq-one", _type: "faq", richText: [], title: "First" },
+          { _id: "faq-two", _type: "faq", richText: [], title: "Second" },
+        ],
+        title: "Questions",
+      },
+    ]);
+
+    const reconciled = reconcilePageBuilder(current, [
+      {
+        _key: "faqs",
+        _type: "faqAccordion",
+        faqs: [
+          { _key: "two", _ref: "faq-two", _type: "reference" },
+          { _key: "new", _ref: "faq-new", _type: "reference" },
+          { _key: "one", _ref: "faq-one", _type: "reference" },
+        ],
+        title: "Questions",
+      },
+    ]);
+
+    expect(resultBlock(reconciled, 0).faqs).toEqual([
+      { _id: "faq-two", _type: "faq", richText: [], title: "Second" },
+      { _id: "faq-one", _type: "faq", richText: [], title: "First" },
+    ]);
+  });
+
+  test("resolves external links and omits newly unresolved internal links", () => {
+    const current = projectedBlocks([
+      {
+        _key: "cards",
+        _type: "imageLinkCards",
+        buttons: [],
+        cards: [
+          {
+            _key: "purchase",
+            _type: "imageLinkCard",
+            description: "Purchase a home",
+            href: "/purchase/",
+            openInNewTab: false,
+            title: "Purchase",
+          },
+        ],
+        title: "Loan options",
+      },
+    ]);
+
+    const reconciled = reconcilePageBuilder(current, [
+      {
+        _key: "cards",
+        _type: "imageLinkCards",
+        buttons: [
+          {
+            _key: "external",
+            _type: "button",
+            text: "External",
+            url: {
+              external: "https://example.com",
+              openInNewTab: true,
+              type: "external",
+            },
+          },
+          {
+            _key: "new-internal",
+            _type: "button",
+            text: "New internal",
+            url: {
+              internal: { _ref: "new-page", _type: "reference" },
+              type: "internal",
+            },
+          },
+        ],
+        cards: [
+          {
+            _key: "purchase",
+            _type: "imageLinkCard",
+            description: "Updated description",
+            title: "Buy a home",
+            url: {
+              internal: { _ref: "purchase-page", _type: "reference" },
+              openInNewTab: false,
+              type: "internal",
+            },
+          },
+        ],
+        title: "Loan options",
+      },
+    ]);
+
+    expect(resultBlock(reconciled, 0).buttons).toEqual([
+      {
+        _key: "external",
+        _type: "button",
+        href: "https://example.com",
+        openInNewTab: true,
+        text: "External",
+      },
+    ]);
+    expect(resultBlock(reconciled, 0).cards).toMatchObject([
+      {
+        _key: "purchase",
+        description: "Updated description",
+        href: "/purchase/",
+        openInNewTab: false,
+        title: "Buy a home",
+      },
+    ]);
+  });
+
+  test("preserves matched projected links that are authoritatively broken", () => {
+    const current = projectedBlocks([
+      {
+        _key: "cta",
+        _type: "cta",
+        buttons: [
+          {
+            _key: "broken",
+            _type: "button",
+            href: null,
+            text: "Broken button",
+          },
+        ],
+        title: "Call to action",
+      },
+      {
+        _key: "cards",
+        _type: "imageLinkCards",
+        cards: [
+          {
+            _key: "broken-card",
+            _type: "imageLinkCard",
+            description: "Broken card",
+            href: null,
+            title: "Broken card",
+          },
+        ],
+        title: "Cards",
+      },
+    ]);
+
+    const reconciled = reconcilePageBuilder(current, [
+      {
+        _key: "cta",
+        _type: "cta",
+        buttons: [
+          {
+            _key: "broken",
+            _type: "button",
+            text: "Still broken",
+            url: {
+              internal: { _ref: "missing-page", _type: "reference" },
+              type: "internal",
+            },
+          },
+        ],
+        title: "Updated call to action",
+      },
+      {
+        _key: "cards",
+        _type: "imageLinkCards",
+        cards: [
+          {
+            _key: "broken-card",
+            _type: "imageLinkCard",
+            description: "Updated broken card",
+            title: "Still broken card",
+            url: {
+              internal: { _ref: "missing-card-page", _type: "reference" },
+              type: "internal",
+            },
+          },
+        ],
+        title: "Cards",
+      },
+    ]);
+
+    expect(resultBlock(reconciled, 0).buttons).toMatchObject([
+      { _key: "broken", href: null, text: "Still broken" },
+    ]);
+    expect(resultBlock(reconciled, 1).cards).toMatchObject([
+      {
+        _key: "broken-card",
+        description: "Updated broken card",
+        href: null,
+        title: "Still broken card",
+      },
+    ]);
+  });
+});

--- a/apps/web/src/components/page-builder-optimistic.test.ts
+++ b/apps/web/src/components/page-builder-optimistic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import type { PageBuilderBlock } from "@/types";
+import type { RawOptimisticPageBuilder } from "./page-builder-optimistic";
 import { reconcilePageBuilder } from "./page-builder-optimistic";
 
 function projectedBlocks(
@@ -506,7 +507,7 @@ describe("reconcilePageBuilder", () => {
           "prototype": { "polluted": true }
         }
       }
-    ]`);
+    ]`) as RawOptimisticPageBuilder;
 
     const reconciled = reconcilePageBuilder([], rawBlocks);
     const block = resultBlock(reconciled, 0);
@@ -539,7 +540,7 @@ describe("reconcilePageBuilder", () => {
           }
         ]
       }
-    ]`);
+    ]`) as RawOptimisticPageBuilder;
 
     const reconciled = reconcilePageBuilder([], rawBlocks);
 

--- a/apps/web/src/components/page-builder-optimistic.ts
+++ b/apps/web/src/components/page-builder-optimistic.ts
@@ -1,0 +1,294 @@
+import type {
+  Page,
+  PageBuilder as RawPageBuilder,
+} from "@workspace/sanity/types";
+
+import type { PageBuilderBlock } from "@/types";
+
+type DeepPartial<T> = T extends readonly (infer Item)[]
+  ? DeepPartial<Item>[]
+  : T extends object
+    ? { [Key in keyof T]?: DeepPartial<T[Key]> }
+    : T;
+
+type GeneratedPageBuilderBlock = RawPageBuilder[number];
+
+export type RawPageBuilderBlock = DeepPartial<GeneratedPageBuilderBlock> &
+  Pick<GeneratedPageBuilderBlock, "_key" | "_type">;
+
+export type RawOptimisticPageBuilder = RawPageBuilderBlock[];
+
+type PageBuilderField = Pick<Page, "pageBuilder">;
+
+export type RawPageBuilderDocument = {
+  readonly [Key in keyof PageBuilderField]?: RawOptimisticPageBuilder;
+};
+
+export type OptimisticPageBuilderAction = {
+  readonly id: string;
+  readonly document?: RawPageBuilderDocument | null;
+};
+
+const NO_SPECIAL_RECONCILIATION = Symbol("no-special-reconciliation");
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(
+  value: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  const field = value?.[key];
+  return typeof field === "string" ? field : undefined;
+}
+
+function referenceId(value: Record<string, unknown> | undefined) {
+  return (
+    stringField(value, "_ref") ??
+    stringField(value, "_id") ??
+    (isObject(value?.document) ? stringField(value.document, "_id") : undefined)
+  );
+}
+
+function findProjectedItem(
+  currentItems: unknown[],
+  rawItem: Record<string, unknown>
+) {
+  const rawKey = stringField(rawItem, "_key");
+  const rawReference = stringField(rawItem, "_ref");
+
+  return currentItems.find((item) => {
+    if (!isObject(item)) {
+      return false;
+    }
+    if (rawKey && stringField(item, "_key") === rawKey) {
+      return true;
+    }
+    return rawReference && referenceId(item) === rawReference;
+  });
+}
+
+function reconcileImage(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>,
+  inArray: boolean
+) {
+  const asset = isObject(raw.asset) ? raw.asset : undefined;
+  const id = stringField(asset, "_ref");
+  if (!id) {
+    return undefined;
+  }
+
+  const sameAsset = stringField(current, "id") === id;
+  const image: Record<string, unknown> = { id };
+
+  if (sameAsset) {
+    for (const key of ["alt", "preview"]) {
+      if (current?.[key] !== undefined) {
+        image[key] = current[key];
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (key === "asset" || (key === "_type" && !inArray && !current?._type)) {
+      continue;
+    }
+    image[key] = reconcileValue(current?.[key], value, key, false);
+  }
+
+  return image;
+}
+
+function resolveRawHref(rawUrl: Record<string, unknown>) {
+  const type = stringField(rawUrl, "type");
+  if (type === "external") {
+    return stringField(rawUrl, "external") ?? stringField(rawUrl, "href");
+  }
+  if (type !== "internal") {
+    return stringField(rawUrl, "href");
+  }
+  return undefined;
+}
+
+function resolveOptimisticHref(
+  current: Record<string, unknown> | undefined,
+  rawUrl: Record<string, unknown>
+) {
+  return (
+    resolveRawHref(rawUrl) ??
+    (stringField(rawUrl, "type") === "internal"
+      ? stringField(current, "href")
+      : undefined)
+  );
+}
+
+function reconcileButton(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>
+) {
+  const url = isObject(raw.url) ? raw.url : undefined;
+  const resolvedHref = url ? resolveOptimisticHref(current, url) : undefined;
+
+  if (!resolvedHref && !current) {
+    return undefined;
+  }
+
+  const button: Record<string, unknown> = {
+    href: resolvedHref ?? current?.href,
+  };
+  for (const key of ["_key", "_type", "text", "variant"] as const) {
+    if (raw[key] !== undefined) {
+      button[key] = raw[key];
+    }
+  }
+  button.openInNewTab = url?.openInNewTab ?? false;
+  return button;
+}
+
+function rawLinkSource(raw: Record<string, unknown>) {
+  if (isObject(raw.customLink)) {
+    return raw.customLink;
+  }
+  if (isObject(raw.url)) {
+    return raw.url;
+  }
+  return undefined;
+}
+
+function reconcileDirectLink(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>
+) {
+  const href = resolveOptimisticHref(current, raw);
+  if (!href && !current) {
+    return undefined;
+  }
+  return {
+    href: href ?? current?.href,
+    openInNewTab: raw.openInNewTab ?? false,
+  };
+}
+
+function reconcileReference(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>
+) {
+  const rawReference = stringField(raw, "_ref");
+  if (!rawReference || referenceId(current) !== rawReference) {
+    return undefined;
+  }
+  return current;
+}
+
+function reconcileArray(current: unknown, raw: unknown[], fieldName?: string) {
+  if (raw.every((item) => !isObject(item))) {
+    return raw;
+  }
+
+  const currentItems = Array.isArray(current) ? current : [];
+  return raw.flatMap((rawItem) => {
+    if (!isObject(rawItem)) {
+      return [rawItem];
+    }
+    const currentItem = findProjectedItem(currentItems, rawItem);
+    const reconciled = reconcileValue(currentItem, rawItem, fieldName, true);
+    return reconciled === undefined ? [] : [reconciled];
+  });
+}
+
+function reconcileSpecialObject(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>,
+  fieldName?: string,
+  inArray = false
+) {
+  if (isObject(raw.asset) || current?.id !== undefined) {
+    return reconcileImage(current, raw, inArray);
+  }
+  if (fieldName === "buttons") {
+    return reconcileButton(current, raw);
+  }
+  if (fieldName === "link" && stringField(raw, "type")) {
+    return reconcileDirectLink(current, raw);
+  }
+  if (stringField(raw, "_ref")) {
+    return reconcileReference(current, raw);
+  }
+  return NO_SPECIAL_RECONCILIATION;
+}
+
+function reconcileRawFields(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>
+) {
+  const reconciled: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    reconciled[key] = reconcileValue(current?.[key], value, key, false);
+  }
+  return reconciled;
+}
+
+function reconcileAliasedLinkObject(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>,
+  linkSource: Record<string, unknown>
+) {
+  const resolvedHref = resolveOptimisticHref(current, linkSource);
+  if (!resolvedHref && !current) {
+    return undefined;
+  }
+
+  const reconciled = reconcileRawFields(current, raw);
+  reconciled.href = resolvedHref ?? current?.href;
+  reconciled.openInNewTab = linkSource.openInNewTab ?? false;
+  return reconciled;
+}
+
+function reconcileObject(
+  current: Record<string, unknown> | undefined,
+  raw: Record<string, unknown>,
+  fieldName?: string,
+  inArray = false
+) {
+  const special = reconcileSpecialObject(current, raw, fieldName, inArray);
+  if (special !== NO_SPECIAL_RECONCILIATION) {
+    return special;
+  }
+
+  const linkSource = rawLinkSource(raw);
+  if (linkSource) {
+    return reconcileAliasedLinkObject(current, raw, linkSource);
+  }
+
+  return reconcileRawFields(current, raw);
+}
+
+function reconcileValue(
+  current: unknown,
+  raw: unknown,
+  fieldName?: string,
+  inArray = false
+): unknown {
+  if (Array.isArray(raw)) {
+    return reconcileArray(current, raw, fieldName);
+  }
+  if (isObject(raw)) {
+    return reconcileObject(
+      isObject(current) ? current : undefined,
+      raw,
+      fieldName,
+      inArray
+    );
+  }
+  return raw;
+}
+
+export function reconcilePageBuilder(
+  currentBlocks: PageBuilderBlock[],
+  rawBlocks: RawOptimisticPageBuilder
+): PageBuilderBlock[] {
+  const reconciled = reconcileArray(currentBlocks, rawBlocks);
+  return reconciled as PageBuilderBlock[];
+}

--- a/apps/web/src/components/page-builder-optimistic.ts
+++ b/apps/web/src/components/page-builder-optimistic.ts
@@ -143,14 +143,8 @@ function reconcileButton(
     return undefined;
   }
 
-  const button: Record<string, unknown> = {
-    href: resolvedHref ?? current?.href,
-  };
-  for (const key of ["_key", "_type", "text", "variant"] as const) {
-    if (raw[key] !== undefined) {
-      button[key] = raw[key];
-    }
-  }
+  const button = reconcileRawFields(current, raw);
+  button.href = resolvedHref ?? current?.href;
   button.openInNewTab = url?.openInNewTab ?? false;
   return button;
 }

--- a/apps/web/src/components/page-builder-optimistic.ts
+++ b/apps/web/src/components/page-builder-optimistic.ts
@@ -30,6 +30,11 @@ export type OptimisticPageBuilderAction = {
 };
 
 const NO_SPECIAL_RECONCILIATION = Symbol("no-special-reconciliation");
+const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isUnsafeObjectKey(key: string) {
+  return UNSAFE_OBJECT_KEYS.has(key);
+}
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -92,6 +97,9 @@ function reconcileImage(
   }
 
   for (const [key, value] of Object.entries(raw)) {
+    if (isUnsafeObjectKey(key)) {
+      continue;
+    }
     if (key === "asset" || (key === "_type" && !inArray && !current?._type)) {
       continue;
     }
@@ -225,6 +233,9 @@ function reconcileRawFields(
 ) {
   const reconciled: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(raw)) {
+    if (isUnsafeObjectKey(key)) {
+      continue;
+    }
     reconciled[key] = reconcileValue(current?.[key], value, key, false);
   }
   return reconciled;

--- a/apps/web/src/components/pagebuilder.test.tsx
+++ b/apps/web/src/components/pagebuilder.test.tsx
@@ -149,3 +149,35 @@ test("PageBuilder keeps an authoritative broken link visible during an optimisti
     optimisticState.action = undefined;
   }
 });
+
+test("PageBuilder distinguishes an omitted page builder from an explicit deletion", () => {
+  const block = {
+    _key: "hero",
+    _type: "hero",
+    buttons: [],
+    richText: [],
+    title: "Keep projected content",
+  } as unknown as PageBuilderBlock;
+
+  try {
+    optimisticState.action = {
+      document: {},
+      id: "homePage",
+    };
+    const preservedHtml = renderToStaticMarkup(
+      <PageBuilder id="homePage" pageBuilder={[block]} type="homePage" />
+    );
+    expect(preservedHtml).toContain("Keep projected content");
+
+    optimisticState.action = {
+      document: { pageBuilder: [] },
+      id: "homePage",
+    };
+    const deletedHtml = renderToStaticMarkup(
+      <PageBuilder id="homePage" pageBuilder={[block]} type="homePage" />
+    );
+    expect(deletedHtml).not.toContain("Keep projected content");
+  } finally {
+    optimisticState.action = undefined;
+  }
+});

--- a/apps/web/src/components/pagebuilder.test.tsx
+++ b/apps/web/src/components/pagebuilder.test.tsx
@@ -1,0 +1,151 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test, vi } from "vitest";
+
+import type { OptimisticPageBuilderAction } from "./page-builder-optimistic";
+
+const optimisticState = vi.hoisted(() => ({
+  action: undefined as OptimisticPageBuilderAction | undefined,
+}));
+
+vi.mock("@sanity/visual-editing/react", () => ({
+  useOptimistic: (
+    initialState: PageBuilderBlock[],
+    reducer: (
+      current: PageBuilderBlock[],
+      action: OptimisticPageBuilderAction
+    ) => PageBuilderBlock[]
+  ) =>
+    optimisticState.action
+      ? reducer(initialState, optimisticState.action)
+      : initialState,
+}));
+
+import type { PageBuilderBlock } from "@/types";
+import { PageBuilder } from "./pagebuilder";
+
+test("PageBuilder keeps projected media and links valid during an optimistic edit", () => {
+  const block = {
+    _key: "hero",
+    _type: "hero",
+    buttons: [
+      {
+        _key: "contact",
+        _type: "button",
+        href: "/contact/",
+        openInNewTab: false,
+        text: "Schedule a call",
+        variant: "default",
+      },
+    ],
+    image: {
+      alt: "A family outside their home",
+      id: "image-abc123-1200x900-jpg",
+      preview: "data:image/jpeg;base64,preview",
+    },
+    richText: [],
+    title: "Original title",
+  } as unknown as PageBuilderBlock;
+
+  optimisticState.action = {
+    document: {
+      pageBuilder: [
+        {
+          _key: "hero",
+          _type: "hero",
+          buttons: [
+            {
+              _key: "contact",
+              _type: "button",
+              text: "Contact us",
+              url: {
+                _type: "customUrl",
+                internal: { _ref: "contact-page", _type: "reference" },
+                openInNewTab: false,
+                type: "internal",
+              },
+              variant: "outline",
+            },
+          ],
+          image: {
+            _type: "image",
+            asset: {
+              _ref: "image-abc123-1200x900-jpg",
+              _type: "reference",
+            },
+          },
+          richText: [],
+          title: "Updated title",
+        },
+      ],
+    },
+    id: "homePage",
+  };
+
+  try {
+    const html = renderToStaticMarkup(
+      <PageBuilder id="homePage" pageBuilder={[block]} type="homePage" />
+    );
+
+    expect(html).toContain("Updated title");
+    expect(html).toContain("Contact us");
+    expect(html).toContain('href="/contact"');
+    expect(html).toContain("A family outside their home");
+    expect(html).not.toContain("Link Broken");
+  } finally {
+    optimisticState.action = undefined;
+  }
+});
+
+test("PageBuilder keeps an authoritative broken link visible during an optimistic edit", () => {
+  const block = {
+    _key: "cta",
+    _type: "cta",
+    buttons: [
+      {
+        _key: "broken",
+        _type: "button",
+        href: null,
+        text: "Broken pathway",
+      },
+    ],
+    richText: [],
+    title: "Original title",
+  } as unknown as PageBuilderBlock;
+
+  optimisticState.action = {
+    document: {
+      pageBuilder: [
+        {
+          _key: "cta",
+          _type: "cta",
+          buttons: [
+            {
+              _key: "broken",
+              _type: "button",
+              text: "Still broken",
+              url: {
+                _type: "customUrl",
+                internal: { _ref: "missing-page", _type: "reference" },
+                type: "internal",
+              },
+            },
+          ],
+          richText: [],
+          title: "Updated title",
+        },
+      ],
+    },
+    id: "homePage",
+  };
+
+  try {
+    const html = renderToStaticMarkup(
+      <PageBuilder id="homePage" pageBuilder={[block]} type="homePage" />
+    );
+
+    expect(html).toContain("Updated title");
+    expect(html).toContain("Link Broken");
+  } finally {
+    optimisticState.action = undefined;
+  }
+});

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -116,11 +116,11 @@ function useOptimisticPageBuilder(
   return useOptimistic<PageBuilderBlock[], RawPageBuilderDocument>(
     initialBlocks,
     (currentBlocks, action) => {
-      if (action.id === documentId && action.document) {
-        return reconcilePageBuilder(
-          currentBlocks,
-          action.document.pageBuilder ?? []
-        );
+      if (
+        action.id === documentId &&
+        action.document?.pageBuilder !== undefined
+      ) {
+        return reconcilePageBuilder(currentBlocks, action.document.pageBuilder);
       }
       return currentBlocks;
     }

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -11,6 +11,10 @@ import { RichTextBlock } from "@workspace/sanity-blocks/rich-text-block/index";
 import { SubscribeNewsletter } from "@workspace/sanity-blocks/subscribe-newsletter/index";
 import { createDataAttribute } from "next-sanity";
 
+import {
+  type RawPageBuilderDocument,
+  reconcilePageBuilder,
+} from "@/components/page-builder-optimistic";
 import type { PageBuilderBlock, PagebuilderType } from "@/types";
 
 export type PageBuilderProps = {
@@ -109,12 +113,14 @@ function useOptimisticPageBuilder(
   initialBlocks: PageBuilderBlock[],
   documentId: string
 ) {
-  // biome-ignore lint/suspicious/noExplicitAny: <any is used to allow for dynamic component rendering>
-  return useOptimistic<PageBuilderBlock[], any>(
+  return useOptimistic<PageBuilderBlock[], RawPageBuilderDocument>(
     initialBlocks,
     (currentBlocks, action) => {
-      if (action.id === documentId && action.document?.pageBuilder) {
-        return action.document.pageBuilder;
+      if (action.id === documentId && action.document) {
+        return reconcilePageBuilder(
+          currentBlocks,
+          action.document.pageBuilder ?? []
+        );
       }
       return currentBlocks;
     }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
+
+const configDirectory = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   esbuild: {
@@ -10,13 +13,13 @@ export default defineConfig({
       {
         find: "@workspace/env/client",
         replacement: path.resolve(
-          __dirname,
+          configDirectory,
           "../../packages/sanity-blocks/src/internal/testing/env.mock.ts"
         ),
       },
       {
         find: "@",
-        replacement: path.resolve(__dirname, "src"),
+        replacement: path.resolve(configDirectory, "src"),
       },
     ],
   },

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  resolve: {
+    alias: [
+      {
+        find: "@workspace/env/client",
+        replacement: path.resolve(
+          __dirname,
+          "../../packages/sanity-blocks/src/internal/testing/env.mock.ts"
+        ),
+      },
+      {
+        find: "@",
+        replacement: path.resolve(__dirname, "src"),
+      },
+    ],
+  },
+  test: {
+    environment: "node",
+    include: ["src/components/**/*.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.6(@types/node@25.5.0)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.23.0)(yaml@2.9.0)
 
   packages/env:
     dependencies:


### PR DESCRIPTION
## Summary

- reconcile raw Sanity Presentation updates with the last projected page-builder state
- keep projected images, buttons, Portable Text links/images, FAQ references, and image-card links renderable during optimistic edits
- preserve immediate compatible field edits, additions, deletions, and array ordering
- add unit and rendered PageBuilder regression coverage

## Root cause

`useOptimistic` replaced the GROQ-projected `pageBuilder` result with the raw document array emitted by Presentation. Raw images expose `asset._ref` instead of `id`, while raw links and buttons expose nested URL fields instead of projected `href` values. Renderers therefore temporarily lost images and displayed `Link Broken` until Sanity Live returned a projected result.

## Impact

Optimistic edits now retain the last valid projected values when raw data cannot resolve them. New image references and external links still update immediately; newly unresolved internal links/references are temporarily omitted. Existing authoritative malformed links remain visible as broken rather than being hidden.

## Validation

- `pnpm --filter web test` — 9 tests passed
- `pnpm --filter @workspace/sanity-blocks test` — 175 tests passed
- `pnpm check-types`
- `pnpm lint`
- `pnpm format:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optimistic Page Builder updates so blocks, FAQ ordering, images, buttons, and links reconcile correctly while preserving projected content.
  * Kept “Link Broken” indicators accurate for unresolved internal pages and preserved authoritative broken link states.
  * Hardened optimistic reconciliation by normalizing URL/link shapes and stripping unsafe/malformed keys from payloads.
* **Tests**
  * Added Vitest coverage for reconciliation scenarios, including deletions vs omitted updates and URL resolution behavior.
  * Added web app Vitest setup and a `test` script, with discovery focused on existing component tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->