### PR TITLE
Add Shelve config for monorepo secret sync

### DIFF
--- a/.aiderignore
+++ b/.aiderignore
@@ -1,0 +1,9 @@
+# shelve-managed-block
+# Added by `shelve init` — do not let AI agents exfiltrate secrets
+.env
+.env.*
+!.env.template
+!.env.example
+.shelve/
+.shelve/cache/
+# end shelve-managed-block

--- a/.aigignore
+++ b/.aigignore
@@ -1,0 +1,9 @@
+# shelve-managed-block
+# Added by `shelve init` — do not let AI agents exfiltrate secrets
+.env
+.env.*
+!.env.template
+!.env.example
+.shelve/
+.shelve/cache/
+# end shelve-managed-block

--- a/.codeiumignore
+++ b/.codeiumignore
@@ -1,0 +1,9 @@
+# shelve-managed-block
+# Added by `shelve init` — do not let AI agents exfiltrate secrets
+.env
+.env.*
+!.env.template
+!.env.example
+.shelve/
+.shelve/cache/
+# end shelve-managed-block

--- a/.continueignore
+++ b/.continueignore
@@ -1,0 +1,9 @@
+# shelve-managed-block
+# Added by `shelve init` — do not let AI agents exfiltrate secrets
+.env
+.env.*
+!.env.template
+!.env.example
+.shelve/
+.shelve/cache/
+# end shelve-managed-block

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,9 @@
+# shelve-managed-block
+# Added by `shelve init` — do not let AI agents exfiltrate secrets
+.env
+.env.*
+!.env.template
+!.env.example
+.shelve/
+.shelve/cache/
+# end shelve-managed-block

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,10 @@ npm-debug.log*
 
 # Claude
 .claude/settings.local.json
+# shelve-managed-block
+.env
+.env.*
+!.env.template
+!.env.example
+.shelve/
+# end shelve-managed-block

--- a/apps/studio/shelve.json
+++ b/apps/studio/shelve.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://shelve.cloud/schema.json",
+  "project": "turbo-start-sanity-studio",
+  "envFileName": ".env.local"
+}

--- a/apps/web/shelve.json
+++ b/apps/web/shelve.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://shelve.cloud/schema.json",
+  "project": "turbo-start-sanity-web",
+  "envFileName": ".env.local"
+}

--- a/shelve.json
+++ b/shelve.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://shelve.cloud/schema.json",
+  "slug": "robotostudio",
+  "defaultEnv": "development",
+  "sync": {
+    "protectedEnvironments": ["production"],
+    "environments": {
+      "development": { "sourceOfTruth": "local" },
+      "production": { "sourceOfTruth": "remote", "allowPush": false, "pullMode": "merge" }
+    }
+  }
+}


### PR DESCRIPTION
Puts the env vars for web and studio in Shelve instead of passing `.env` files around.

## Layout

Shelve merges a root `shelve.json` into each package-level one, so the team slug and sync policy only get set once:

- `shelve.json` holds the slug, default env, and sync policy
- `apps/web/shelve.json` sets project `turbo-start-sanity-web`
- `apps/studio/shelve.json` sets project `turbo-start-sanity-studio`

Two projects rather than one, because the key sets don't overlap and merging them into a single namespace makes the Shelve UI harder to read.

Both apps set `envFileName` to `.env.local`, which is what Next.js and the Studio's Vite loader already read. Shelve defaults to `.env`, so without this it would write to a file nothing loads.

## Sync policy

`production` is in `protectedEnvironments` with `allowPush: false`, so pushing to prod from a laptop fails at the client and again at the server. `development` treats local as source of truth.

## Using it

```bash
shelve run -- pnpm dev          # from apps/web or apps/studio
shelve diff --env development   # check for drift
```

`shelve run` injects into the child process, so no plaintext `.env` sits on disk where an agent can read it.

## The empty-value trap

Shelve's API rejects variables with empty values, and returns a 400 for the whole batch rather than skipping the offending key. The studio env hit this with two placeholder keys, `SANITY_STUDIO_APP_ID=` and `SANITY_STUDIO_API_VERSION=`.

Those turned out to be wrong on their own terms too. `apps/studio/utils/constant.ts:45` reads:

```ts
export const API_VERSION = process.env.SANITY_STUDIO_API_VERSION ?? "2025-05-08";
```

`??` only falls through on null or undefined, so `SANITY_STUDIO_API_VERSION=` sets the API version to an empty string instead of the intended default. Leaving the key unset is the only way to get `2025-05-08`.

Worth a follow-up: `apps/studio/.env.example` still ships both keys as empty, so anyone who copies it inherits the same broken API version. Not touched here to keep this PR to the Shelve change.

## Not included

`.env.local` files aren't in this PR, they're gitignored. Values are already pushed to Shelve's `development` env for both projects.

`packages/sanity` and `packages/sanity-blocks` have `.env.example` files but no Shelve project yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project configuration for managing development and production environments.
  * Added app-specific configuration for the web and studio applications.
* **Security**
  * Added safeguards to exclude environment secrets and local Shelve cache data from AI-assisted tooling and version control.
  * Preserved example environment templates for setup guidance.
* **Configuration**
  * Defined protected production settings and controlled synchronization behavior between local and remote environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->