### PR TITLE
Fix 18 SonarQube findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Cache Turbo
         uses: actions/cache@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install Playwright Chromium
         run: pnpm --filter web exec playwright install --with-deps chromium

--- a/apps/studio/components/url-slug/validation-messages.tsx
+++ b/apps/studio/components/url-slug/validation-messages.tsx
@@ -1,9 +1,9 @@
 import { Card, Stack, Text } from "@sanity/ui";
 
-type ValidationMessagesProps = {
+type ValidationMessagesProps = Readonly<{
   errors?: string[];
   warnings?: string[];
-};
+}>;
 
 const errorTextStyle = {
   color: "var(--card-badge-critical-fg-color)",

--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -74,9 +74,9 @@ export async function generateMetadata({
 
 export default async function SlugPage({
   params,
-}: {
+}: Readonly<{
   params: Promise<SlugParams>;
-}) {
+}>) {
   const { isEnabled: isDraftMode } = await draftMode();
   if (isDraftMode) {
     return (
@@ -97,7 +97,9 @@ export default async function SlugPage({
   return <SlugPageContent pageData={pageData} />;
 }
 
-async function DynamicSlugPage({ params }: { params: Promise<SlugParams> }) {
+async function DynamicSlugPage({
+  params,
+}: Readonly<{ params: Promise<SlugParams> }>) {
   const [{ slug }, { perspective, stega }] = await Promise.all([
     params,
     getDynamicFetchOptions(),
@@ -128,9 +130,9 @@ async function getCachedSlugPage({
 
 function SlugPageContent({
   pageData,
-}: {
+}: Readonly<{
   pageData: NonNullable<Awaited<ReturnType<typeof getCachedSlugPage>>>;
-}) {
+}>) {
   const { title, pageBuilder, _id, _type } = pageData ?? {};
 
   if (!Array.isArray(pageBuilder) || pageBuilder?.length === 0) {

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -105,7 +105,9 @@ export default async function BlogSlugPage({
   return <BlogPageContent data={data} />;
 }
 
-async function DynamicBlogPage({ params }: { params: Promise<BlogParams> }) {
+async function DynamicBlogPage({
+  params,
+}: Readonly<{ params: Promise<BlogParams> }>) {
   const [{ slug }, { perspective, stega }] = await Promise.all([
     params,
     getDynamicFetchOptions(),
@@ -136,9 +138,9 @@ async function getCachedBlogPage({
 
 function BlogPageContent({
   data,
-}: {
+}: Readonly<{
   data: NonNullable<Awaited<ReturnType<typeof getCachedBlogPage>>>;
-}) {
+}>) {
   const { title, description, image, richText } = data ?? {};
 
   return (

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -81,11 +81,11 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-type BlogPageProps = {
+type BlogPageProps = Readonly<{
   searchParams: Promise<{
     page?: string;
   }>;
-};
+}>;
 
 export default function BlogIndexPage({ searchParams }: BlogPageProps) {
   return (

--- a/apps/web/src/components/json-ld.tsx
+++ b/apps/web/src/components/json-ld.tsx
@@ -23,9 +23,9 @@ import { getBaseUrl } from "@/utils";
 // matters; the result stays valid JSON for crawlers.
 function serializeJsonLd<T>(data: T): string {
   return JSON.stringify(data)
-    .replaceAll("<", "\\u003c")
-    .replaceAll(">", "\\u003e")
-    .replaceAll("&", "\\u0026");
+    .replaceAll("<", String.raw`\u003c`)
+    .replaceAll(">", String.raw`\u003e`)
+    .replaceAll("&", String.raw`\u0026`);
 }
 
 export function JsonLdScript<T>({ data, id }: { data: T; id: string }) {

--- a/apps/web/src/components/page-builder-json-ld.tsx
+++ b/apps/web/src/components/page-builder-json-ld.tsx
@@ -6,15 +6,15 @@ import type { PageBuilderBlock, PagebuilderType } from "@/types";
 
 export function PageBuilderJsonLd({
   pageBuilder,
-}: {
+}: Readonly<{
   pageBuilder?: PageBuilderBlock[] | null;
-}) {
+}>) {
   if (!pageBuilder?.length) return null;
 
   return (
     <>
       {pageBuilder.map((block) => {
-        if (!block || block._type !== "faqAccordion") return null;
+        if (block?._type !== "faqAccordion") return null;
         const data = faqAccordionToJsonLd(
           stegaClean(block as PagebuilderType<"faqAccordion">)
         );

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -49,10 +49,7 @@ async function resolveSiteConfig(): Promise<SiteConfig> {
     query: queryGlobalSeoSettings,
     perspective,
   });
-  const twitter = settings?.socialLinks?.twitter
-    ?.split("/")
-    .filter(Boolean)
-    .pop();
+  const twitter = settings?.socialLinks?.twitter?.split("/").findLast(Boolean);
   return {
     title: settings?.siteTitle || FALLBACK_SITE_CONFIG.title,
     description: settings?.siteDescription || FALLBACK_SITE_CONFIG.description,

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -47,6 +47,6 @@ export function proxy(request: NextRequest): NextResponse {
 
 export const config = {
   matcher: [
-    "/((?!api/|_next/|favicon.ico|robots.txt|sitemap.xml|llms\\.txt).*)",
+    "/((?!api/|_next/|favicon.ico|robots.txt|sitemap.xml|llms[.]txt).*)",
   ],
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@workspace/typescript-config/nextjs.json",
   "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "paths": {
       "@/*": ["./src/*"],
       "@workspace/ui/*": ["../../packages/ui/src/*"],

--- a/packages/sanity-blocks/src/internal/page-builder-to-markdown.ts
+++ b/packages/sanity-blocks/src/internal/page-builder-to-markdown.ts
@@ -10,16 +10,12 @@ import { faqAccordionToMarkdown } from "../faq-accordion/markdown";
 import { featureCardsIconToMarkdown } from "../feature-cards-icon/markdown";
 import { heroToMarkdown } from "../hero/markdown";
 import { imageLinkCardsToMarkdown } from "../image-link-cards/markdown";
-import {
-  type MarkdownBlock,
-  type MarkdownOptions,
-  imageToMarkdown,
-} from "./markdown";
+import type { MarkdownBlock, MarkdownOptions } from "./markdown";
 import { richTextBlockToMarkdown } from "../rich-text-block/markdown";
 import { subscribeNewsletterToMarkdown } from "../subscribe-newsletter/markdown";
 
+export { imageToMarkdown } from "./markdown";
 export type { MarkdownBlock };
-export { imageToMarkdown };
 
 function blockToMarkdown(
   block: MarkdownBlock,


### PR DESCRIPTION
Clears 18 of the 19 SonarQube findings. The 19th is a false positive that can only be closed from the SonarCloud UI, details at the bottom.

## CI workflows

`pnpm install --frozen-lockfile --ignore-scripts` in `ci.yml` and `e2e.yml`.

Skipping install scripts is safe because neither job builds:

- `turbo.json` has `lint`, `format:check` and `check-types` depending on `transit`, not `^build`
- `playwright.config.ts` gates its `webServer` block behind `!process.env.CI`, and `e2e.yml` sets `CI: true`, so the e2e job hits the deployed Vercel URL

So the `onlyBuiltDependencies` allowlist (`esbuild`, `sharp`, `@tailwindcss/oxide`) and the `apps/studio` postinstall never get exercised in CI.

Worth watching: if a test step is ever added to `ci.yml`, those native builds will be missing. The fix then is an explicit `pnpm rebuild esbuild` step, not dropping the flag.

## Readonly props (S6759)

Nine findings across five files. `blog/page.tsx` and `validation-messages.tsx` wrap the shared type alias rather than each call site, so one edit covers both findings in each file.

## String.raw (S7780)

`json-ld.tsx` only. The three unicode escapes become `String.raw` templates. Byte-identical output, checked against a `</script><b>&amp;` payload:

    {"t":"\u003c/script\u003e\u003cb\u003e\u0026amp;"}

Flagging this one because the obvious-looking version of the fix (a literal `<` inside the template instead of the escape sequence) turns the whole thing into a no-op and silently drops the script-breakout protection.

## proxy.ts matcher

Same rule, different fix. `export const config` is read by Next through static AST analysis without running the module, so a tagged template isn't statically evaluable. Character class instead:

```diff
-    "/((?!api/|_next/|favicon.ico|robots.txt|sitemap.xml|llms\\.txt).*)",
+    "/((?!api/|_next/|favicon.ico|robots.txt|sitemap.xml|llms[.]txt).*)",
```

`.next/server/functions-config-manifest.json` shows Next read the literal verbatim, and the compiled regex agrees with the old one on all 12 paths I checked (`/llms.txt`, `/about.md`, `/blog/post.md`, `/robots.txt`, `/_next/static/a.js` and so on).

## findLast

`seo.ts` swaps `.filter(Boolean).pop()` for `.findLast(Boolean)`, which is ES2023. `apps/web/tsconfig.json` now sets `lib` explicitly instead of inheriting `es2022`. Scoped to web on purpose, since editing `packages/typescript-config/base.json` would ripple to studio and every package for the sake of one line.

## Re-export

`page-builder-to-markdown.ts` re-exports `imageToMarkdown` directly instead of importing it only to export it again.

## Verification

    pnpm format        7 tasks
    pnpm lint          7 tasks
    pnpm format:check  7 tasks
    pnpm check-types   6 tasks, forced, no cache
    pnpm build:web     ok
    vitest             175 passed

## Needs a manual mark

`e2e.yml:44`, `pnpm --filter web exec playwright install --with-deps chromium`.

Sonar matched on the word `install`, but that command downloads browser binaries and isn't a package install. Its only options are `--with-deps`, `--dry-run`, `--list`, `--force`, `--only-shell` and `--no-shell` (playwright-core `lib/cli/program.js:127`), so passing `--ignore-scripts` would fail with an unknown option. Marking it Safe in the SonarCloud UI is the only way to close it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON-LD escaping to help protect structured data embedded in pages.
  - Improved Twitter handle extraction from social profile URLs.
  - Refined route handling so `llms.txt` is correctly excluded from proxy processing.

- **Refactor**
  - Strengthened internal type safety and immutability across page and component interfaces.
  - Updated TypeScript configuration and markdown utility exports for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->