### PR TITLE
Presentation Drafts In Any Environment, Plus Blog And UI Review Fixes

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Logger } from "@workspace/logger";
 import {
-  DRAFT_MODE_ENABLED,
+  DRAFTS_WITHOUT_SESSION,
   type DynamicFetchOptions,
   getDynamicFetchOptions,
   resolvePageFetchOptions,
@@ -10,6 +10,7 @@ import {
 } from "@workspace/sanity/live";
 import { querySlugPageData, querySlugPagePaths } from "@workspace/sanity/query";
 import type { Metadata } from "next";
+import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
@@ -75,15 +76,20 @@ export async function generateMetadata({
 export default async function SlugPage({
   params,
 }: Readonly<{ params: Promise<SlugParams> }>) {
-  // Dev/preview: draft-aware path so unpublished pages still render.
-  if (DRAFT_MODE_ENABLED) {
+  const { isEnabled: isDraftMode } = await draftMode();
+
+  // A Presentation session (any environment) or local dev takes the draft-aware
+  // path, so draft edits and unpublished pages render.
+  if (isDraftMode || DRAFTS_WITHOUT_SESSION) {
     return (
       <Suspense fallback={<HeroFallback />}>
         <SlugPageInner params={params} />
       </Suspense>
     );
   }
-  // Production: static published render with a real 404, no skeleton.
+
+  // Everyone else: published render off the same cached fetch as before, and a
+  // real 404 — not a soft one streamed inside Suspense.
   const { slug } = await params;
   const pageData = await getPublishedSlugPage(slug);
   if (!pageData) {

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Logger } from "@workspace/logger";
 import {
-  DRAFT_MODE_ENABLED,
+  DRAFTS_WITHOUT_SESSION,
   type DynamicFetchOptions,
   getDynamicFetchOptions,
   resolvePageFetchOptions,
@@ -15,6 +15,7 @@ import {
 } from "@workspace/sanity-blocks/internal/rich-text";
 import { SanityImage } from "@workspace/sanity-blocks/internal/sanity-image";
 import type { Metadata } from "next";
+import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
@@ -82,15 +83,20 @@ export default async function BlogSlugPage({
 }: Readonly<{
   params: Promise<BlogParams>;
 }>) {
-  // Dev/preview: draft-aware path so unpublished posts still render.
-  if (DRAFT_MODE_ENABLED) {
+  const { isEnabled: isDraftMode } = await draftMode();
+
+  // A Presentation session (any environment) or local dev takes the draft-aware
+  // path, so draft edits and unpublished posts render.
+  if (isDraftMode || DRAFTS_WITHOUT_SESSION) {
     return (
       <Suspense fallback={<BlogFallback />}>
         <BlogSlugInner params={params} />
       </Suspense>
     );
   }
-  // Production: static published render with a real 404, no skeleton.
+
+  // Everyone else: published render off the same cached fetch as before, and a
+  // real 404 — not a soft one streamed inside Suspense.
   const { slug } = await params;
   const data = await getPublishedBlogPage(slug);
   if (!data) {

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -130,8 +130,25 @@ async function fetchBlogIndexPageBlogsCount({
   return res.data;
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const { perspective } = await getDynamicFetchOptions();
+type BlogPageProps = Readonly<{
+  searchParams: Promise<{
+    page?: string;
+    category?: string;
+  }>;
+}>;
+
+export async function generateMetadata({
+  searchParams,
+}: BlogPageProps): Promise<Metadata> {
+  const [{ page, category }, { perspective }] = await Promise.all([
+    searchParams,
+    getDynamicFetchOptions(),
+  ]);
+  await assertBlogPageInRange({
+    page,
+    category: category ?? "",
+    perspective,
+  });
   const { data: result } = await sanityFetchMetadata({
     query: queryBlogIndexPageData,
     perspective,
@@ -139,12 +156,66 @@ export async function generateMetadata(): Promise<Metadata> {
   return seoFromDocument(result, { slug: "/blog" });
 }
 
-type BlogPageProps = Readonly<{
-  searchParams: Promise<{
-    page?: string;
-    category?: string;
-  }>;
-}>;
+/**
+ * `?page=` as a 1-based page number, or `null` when the value is present but
+ * not a positive integer — a bogus URL that should 404 rather than quietly
+ * serve page 1 under a different address.
+ */
+function parseBlogPageParam(page: string | undefined): number | null {
+  if (page === undefined || page === "") {
+    return 1;
+  }
+  const parsed = Number(page);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
+ * 404s a `?page=` past the last page. Lives in `generateMetadata` because that
+ * resolves before the response status is committed; the same `notFound()`
+ * inside the page's Suspense boundary only ever streams a soft 404, since PPR
+ * has already flushed the prerendered shell with a 200.
+ *
+ * `totalPages` floors at 1, so page 1 always survives: an empty blog, and an
+ * empty category filter, are legitimate results rather than dead URLs.
+ */
+async function assertBlogPageInRange({
+  page,
+  category,
+  perspective,
+}: {
+  page: string | undefined;
+  category: string;
+  perspective: DynamicFetchOptions["perspective"];
+}) {
+  const currentPage = parseBlogPageParam(page);
+  if (currentPage === null) {
+    notFound();
+  }
+  if (currentPage === 1) {
+    return;
+  }
+
+  const [totalCount] = await handleErrors(
+    fetchBlogIndexPageBlogsCount({
+      category,
+      excludeFeatured: !category,
+      perspective,
+      stega: false,
+    })
+  );
+  // A failed count is a server problem, not a missing page — let the page
+  // render its error state instead of masking it as a 404.
+  if (totalCount === null || totalCount === undefined) {
+    return;
+  }
+  const { totalPages } = calculateBlogPaginationMetadata(
+    totalCount,
+    currentPage
+  );
+  if (currentPage > totalPages) {
+    notFound();
+  }
+}
 
 export default function BlogIndexPage({ searchParams }: BlogPageProps) {
   return (
@@ -187,18 +258,27 @@ async function DynamicBlogIndex({ searchParams }: BlogPageProps) {
     searchParams,
     getDynamicFetchOptions(),
   ]);
-  const parsedPage = Number(page);
-  const currentPage =
-    Number.isInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+  const currentPage = parseBlogPageParam(page);
+  if (currentPage === null) {
+    notFound();
+  }
   const activeCategory = category ?? "";
 
+  // Keyed so a page/category change mounts a *new* boundary. Without it React
+  // keeps the previous page's posts on screen for the whole round trip — the
+  // URL flips to `?page=2` while the grid still shows page 1.
   return (
-    <BlogIndexView
-      activeCategory={activeCategory}
-      currentPage={currentPage}
-      perspective={perspective}
-      stega={stega}
-    />
+    <Suspense
+      fallback={<BlogIndexShell />}
+      key={`${activeCategory}:${currentPage}`}
+    >
+      <BlogIndexView
+        activeCategory={activeCategory}
+        currentPage={currentPage}
+        perspective={perspective}
+        stega={stega}
+      />
+    </Suspense>
   );
 }
 
@@ -249,6 +329,13 @@ async function BlogIndexView({
     totalCount,
     currentPage
   );
+
+  // Past the last page is a dead URL, not an empty list. `totalPages` floors at
+  // 1, so page 1 still renders when there is nothing to show — including an
+  // empty category filter, which is a legitimate result rather than a 404.
+  if (currentPage > paginationMetadata.totalPages) {
+    notFound();
+  }
 
   const { start: blogStart, end: blogEnd } =
     getBlogPaginationRange(currentPage);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "@workspace/ui/globals.css";
 
 import {
-  DRAFT_MODE_ENABLED,
+  DRAFTS_WITHOUT_SESSION,
   type DynamicFetchOptions,
   getDynamicFetchOptions,
   SanityLive,
@@ -46,10 +46,8 @@ export default async function RootLayout({
   prefetchDNS("https://cdn.sanity.io");
   // In local dev, nav/footer follow drafts too (like page content), so draft
   // navbar/footer/settings edits are visible without a Presentation session.
-  // Production stays static published (DRAFT_MODE_ENABLED is false).
-  const showDrafts = DRAFT_MODE_ENABLED;
-  // Presentation overlay (preview bar, visual editing) needs a real session.
-  const isDraftMode = DRAFT_MODE_ENABLED && (await draftMode()).isEnabled;
+  // Production stays static published.
+  const showDrafts = DRAFTS_WITHOUT_SESSION;
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -79,19 +77,37 @@ export default async function RootLayout({
               <CachedFooter perspective="published" stega={false} />
             )}
           </StickyFooter>
-          <SanityLive action={revalidateSyncTags} includeDrafts={isDraftMode} />
+          {/* Reads draftMode(), so it must stay behind Suspense — otherwise the
+              whole layout opts out of prerendering for every visitor. */}
+          <Suspense fallback={null}>
+            <LivePreviewLayer />
+          </Suspense>
           <Suspense fallback={null}>
             <CombinedJsonLd includeOrganization includeWebsite />
           </Suspense>
-          {isDraftMode && (
-            <>
-              <PreviewBar />
-              <VisualEditing />
-            </>
-          )}
         </Providers>
       </body>
     </html>
+  );
+}
+
+/**
+ * Live updates plus the Presentation overlay. The overlay renders wherever a
+ * validated draft-mode session exists — production included — which is what
+ * lets the deployed Studio preview the live site.
+ */
+async function LivePreviewLayer() {
+  const { isEnabled: isDraftMode } = await draftMode();
+  return (
+    <>
+      <SanityLive action={revalidateSyncTags} includeDrafts={isDraftMode} />
+      {isDraftMode && (
+        <>
+          <PreviewBar />
+          <VisualEditing />
+        </>
+      )}
+    </>
   );
 }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -55,18 +55,17 @@ export default async function RootLayout({
       >
         <Providers>
           <ScrollToTop />
-          {showDrafts ? (
-            <Suspense fallback={<NavbarSkeleton />}>
-              <DynamicNavbar />
-            </Suspense>
-          ) : (
-            <CachedNavbar perspective="published" stega={false} />
-          )}
-          <div
-            className="-mt-16 relative z-10 min-h-dvh bg-background pt-16"
-            style={{ marginBottom: "var(--footer-height)" }}
-          >
-            {children}
+          <div style={{ marginBottom: "var(--footer-height)" }}>
+            {showDrafts ? (
+              <Suspense fallback={<NavbarSkeleton />}>
+                <DynamicNavbar />
+              </Suspense>
+            ) : (
+              <CachedNavbar perspective="published" stega={false} />
+            )}
+            <div className="-mt-16 relative z-10 min-h-dvh bg-background pt-16">
+              {children}
+            </div>
           </div>
           <StickyFooter>
             {showDrafts ? (

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,5 @@
 import {
-  DRAFT_MODE_ENABLED,
+  DRAFTS_WITHOUT_SESSION,
   type DynamicFetchOptions,
   getDynamicFetchOptions,
   resolvePageFetchOptions,
@@ -8,6 +8,7 @@ import {
 } from "@workspace/sanity/live";
 import { queryHomePageData } from "@workspace/sanity/query";
 import type { Metadata } from "next";
+import { draftMode } from "next/headers";
 import { Suspense } from "react";
 
 import { PageBuilderJsonLd } from "@/components/page-builder-json-ld";
@@ -24,16 +25,20 @@ export async function generateMetadata(): Promise<Metadata> {
   return seoFromDocument(homePageData, { slug: "/" });
 }
 
-export default function Page() {
-  // Production static-renders published; dev/preview streams drafts below.
-  if (!DRAFT_MODE_ENABLED) {
-    return <CachedHome perspective="published" stega={false} />;
+export default async function Page() {
+  const { isEnabled: isDraftMode } = await draftMode();
+
+  // A Presentation session (any environment) or local dev streams drafts.
+  if (isDraftMode || DRAFTS_WITHOUT_SESSION) {
+    return (
+      <Suspense fallback={<HeroFallback />}>
+        <HomeContent />
+      </Suspense>
+    );
   }
-  return (
-    <Suspense fallback={<HeroFallback />}>
-      <HomeContent />
-    </Suspense>
-  );
+
+  // Everyone else: published render off the same cache entry as before.
+  return <CachedHome perspective="published" stega={false} />;
 }
 
 async function HomeContent() {

--- a/apps/web/src/components/elements/menu-link.tsx
+++ b/apps/web/src/components/elements/menu-link.tsx
@@ -14,7 +14,7 @@ export function MenuLink({
 
   return (
     <Link
-      className="group flex items-start gap-3 rounded-none p-3 focus-ring-inset hover:bg-zinc-200 dark:hover:bg-zinc-800"
+      className="hover-surface group flex items-start gap-3 rounded-none p-3 focus-ring-inset"
       href={href}
       onClick={onClick}
     >

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -100,13 +100,13 @@ function SocialLinks({ data }: Readonly<SocialLinksProps>) {
         <li key={`social-link-${url}-${index.toString()}`}>
           <Link
             aria-label={label}
-            className="focus-ring-inset group inline-flex cursor-pointer items-center justify-center p-1.5 hover:bg-accent-green-foreground focus-visible:outline-accent-green-foreground!"
+            className="focus-ring-inset group inline-flex cursor-pointer items-center justify-center p-1.5 focus-visible:outline-accent-green-foreground!"
             href={url ?? "#"}
             prefetch={false}
             rel="noopener noreferrer"
             target="_blank"
           >
-            <Icon className="h-[18px] w-auto fill-accent-green-foreground group-hover:fill-accent-green" />
+            <Icon className="h-[18px] w-auto fill-accent-green-foreground transition-opacity duration-200 group-hover:opacity-75" />
             <span className="sr-only">{label}</span>
           </Link>
         </li>

--- a/apps/web/src/components/mobile-menu.tsx
+++ b/apps/web/src/components/mobile-menu.tsx
@@ -145,7 +145,7 @@ export function MobileMenu({
                           aria-current={
                             column.href === pathname ? "page" : undefined
                           }
-                          className="focus-ring-inset -mx-3 flex items-center rounded-none px-3 py-3 font-light font-mono text-foreground text-sm uppercase tracking-normal hover:bg-zinc-200 dark:hover:bg-zinc-800"
+                          className="hover-surface focus-ring-inset -mx-3 flex items-center rounded-none px-3 py-3 font-light font-mono text-foreground text-sm uppercase tracking-normal"
                           href={column.href}
                           key={column._key}
                           onClick={closeMenu}
@@ -162,7 +162,7 @@ export function MobileMenu({
                           key={column._key}
                           value={column._key}
                         >
-                          <AccordionTrigger className="focus-ring-inset -mx-3 rounded-none px-3 py-3 font-light font-mono text-foreground text-sm uppercase tracking-normal hover:bg-zinc-200 dark:hover:bg-zinc-800 hover:no-underline">
+                          <AccordionTrigger className="hover-surface focus-ring-inset -mx-3 rounded-none px-3 py-3 font-light font-mono text-foreground text-sm uppercase tracking-normal hover:no-underline">
                             {column.title}
                           </AccordionTrigger>
                           <AccordionContent>

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -19,21 +19,15 @@ import { Logo } from "@/components/logo";
 import { MobileMenu } from "@/components/mobile-menu";
 import type { ColumnLink, NavigationData } from "@/types";
 
-// Shared by the dropdown triggers and the plain links so the two never drift,
-// and focus mirrors hover so keyboard and pointer land alike. Over a marked
-// section the wash goes translucent: a flat zinc swatch only holds contrast on
-// the one background it was picked for.
-//
-// The wash alone can't carry focus — zinc-200 on white is ~1.2:1, well under
-// the 3:1 a focus indicator needs — so keyboard focus also draws the site's
-// dotted ring. `currentColor`, not `--foreground`, because the text colour
-// already inverts over a marked section and the ring has to follow it.
+// Focus-visible mirrors the `hover-surface` wash so keyboard and pointer land
+// on the same colour. The `data-nav-on` overrides win over both, keeping the
+// translucent treatment where the bar sits on a fixed-ground section.
 const NAV_LINK_CLASS =
-  "h-auto rounded-full bg-transparent px-3 py-2 font-light font-mono text-foreground text-sm uppercase tracking-normal outline-none hover:bg-zinc-200 dark:hover:bg-zinc-800 focus-visible:bg-zinc-200 focus-visible:[outline:2px_dotted_currentColor]! focus-visible:outline-offset-2! dark:focus-visible:bg-zinc-800 data-[nav-on=dark]:text-white data-[nav-on=dark]:hover:bg-white/15 data-[nav-on=dark]:focus-visible:bg-white/15 data-[nav-on=light]:text-zinc-900 data-[nav-on=light]:hover:bg-zinc-900/10 data-[nav-on=light]:focus-visible:bg-zinc-900/10";
+  "hover-surface h-auto rounded-full bg-transparent px-3 py-2 font-light font-mono text-foreground text-sm uppercase tracking-normal outline-none focus-visible:bg-zinc-100 focus-visible:[outline:2px_dotted_currentColor]! focus-visible:outline-offset-2! dark:focus-visible:bg-zinc-900 data-[nav-on=dark]:text-white data-[nav-on=dark]:hover:bg-white/15 data-[nav-on=dark]:focus-visible:bg-white/15 data-[nav-on=light]:text-zinc-900 data-[nav-on=light]:hover:bg-zinc-900/10 data-[nav-on=light]:focus-visible:bg-zinc-900/10";
 
 const TRIGGER_CLASS = cn(
   NAV_LINK_CLASS,
-  "data-popup-open:bg-zinc-100 dark:data-popup-open:bg-zinc-800 data-[nav-on=dark]:data-popup-open:bg-white/15 data-[nav-on=light]:data-popup-open:bg-zinc-900/10"
+  "data-popup-open:bg-zinc-100 dark:data-popup-open:bg-zinc-900 data-[nav-on=dark]:data-popup-open:bg-white/15 data-[nav-on=light]:data-popup-open:bg-zinc-900/10"
 );
 
 // The outline pill draws itself in theme ink, which lands white-on-bright over
@@ -293,7 +287,7 @@ export function Navbar({
                             <li key={link._key}>
                               <NavigationMenuLink
                                 aria-current={currentPage(link.href)}
-                                className="group flex flex-col gap-0.5 rounded-none px-3 py-2.5 focus-ring-inset hover:bg-zinc-200 dark:hover:bg-zinc-800"
+                                className="hover-surface group flex flex-col gap-0.5 rounded-none px-3 py-2.5 focus-ring-inset"
                                 closeOnClick
                                 render={<Link href={link.href ?? "#"} />}
                               >

--- a/apps/web/src/components/navbar.tsx
+++ b/apps/web/src/components/navbar.tsx
@@ -249,7 +249,7 @@ export function Navbar({
 
   return (
     <header
-      className="sticky top-0 z-40 w-full before:absolute before:inset-x-0 before:bottom-full before:h-screen before:bg-background before:content-['']"
+      className="nav-exit sticky top-0 z-40 w-full before:absolute before:inset-x-0 before:bottom-full before:h-screen before:bg-background before:content-['']"
       ref={headerRef}
     >
       <ProgressiveBlur />

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -158,10 +158,10 @@ export async function getSEOMetadata(
       ]
     : undefined;
 
-  const fullTitle =
-    defaultTitle === siteConfig.title
-      ? defaultTitle
-      : `${defaultTitle} / ${siteConfig.title}`;
+  // Page title only — the site name repeated on every tab pushed the part that
+  // distinguishes them out of view. It still reaches crawlers via `creator`,
+  // `authors` and the Open Graph `siteName` below.
+  const fullTitle = defaultTitle;
 
   const markdownUrl =
     slug && slug !== "/" ? `${pageUrl}.md` : `${baseUrl}/index.md`;
@@ -199,6 +199,7 @@ export async function getSEOMetadata(
       countryName: "UK",
       description: socialDescription,
       title: socialTitle,
+      siteName: siteConfig.title,
       images: ogImages,
       url: pageUrl,
     },

--- a/packages/sanity-blocks/src/faq-accordion/index.tsx
+++ b/packages/sanity-blocks/src/faq-accordion/index.tsx
@@ -40,13 +40,12 @@ export interface FaqAccordionProps {
 }
 
 const DISCLOSURE_BASE_CLASS =
-  "hover-surface group border border-border bg-background px-4 has-[summary:focus-visible]:[outline:2px_dotted_var(--foreground)] has-[summary:focus-visible]:[outline-offset:-2px]";
-// `transition-none` because `duration-300` is here for `animate-in`, but the
-// utility also sets `transition-duration`, and CSS defaults `transition-property`
-// to `all` — so the entrance duration was silently fading the hover background
-// too, while the code chip inside switched instantly.
+  "hover-surface group border border-border bg-background px-4 transition-colors duration-150 has-[summary:focus-visible]:[outline:2px_dotted_var(--foreground)] has-[summary:focus-visible]:[outline-offset:-2px] motion-reduce:transition-none";
+// `animation-duration-300`, not `duration-300`: the latter also sets
+// `transition-duration`, which stretched the hover fade above to the entrance's
+// 300ms while the code chip inside switched instantly.
 const DISCLOSURE_ANIMATION_CLASS =
-  "fade-in slide-in-from-bottom-2 animate-in fill-mode-both duration-300 ease-out transition-none motion-reduce:animate-none";
+  "fade-in slide-in-from-bottom-2 animate-in fill-mode-both animation-duration-300 ease-out motion-reduce:animate-none";
 
 function FaqDisclosure({
   animationDelay,

--- a/packages/sanity-blocks/src/internal/code-block.tsx
+++ b/packages/sanity-blocks/src/internal/code-block.tsx
@@ -60,7 +60,7 @@ export function CodeBlock({
             keyboard-focusable on their own, so arrow keys can still pan a long
             line into view (WCAG 2.1.1). */}
         <pre className="rich-code-pre overflow-x-auto font-mono">
-          <code>{code}</code>
+          <code className="font-mono">{code}</code>
         </pre>
       </div>
     </figure>

--- a/packages/sanity/src/live.ts
+++ b/packages/sanity/src/live.ts
@@ -50,18 +50,30 @@ const DRAFTS_FETCH_OPTIONS: DynamicFetchOptions = {
   stega: false,
 };
 
-export const DRAFT_MODE_ENABLED = process.env.NODE_ENV === "development";
+/**
+ * Serve drafts to a request that carries no Presentation session. Local dev
+ * only: anywhere the URL is publicly reachable this would hand unpublished
+ * content to anyone who can load the page.
+ */
+export const DRAFTS_WITHOUT_SESSION = process.env.NODE_ENV === "development";
 
-/** Resolves perspective/stega outside any `'use cache'` boundary (reads draftMode/cookies). */
+/**
+ * Resolves perspective/stega outside any `'use cache'` boundary (reads
+ * draftMode/cookies).
+ *
+ * Drafts may render in any environment — including production — but only for a
+ * request holding a draft-mode session. `/api/presentation-draft` is the only
+ * way to obtain one and it validates a Sanity preview secret, so an anonymous
+ * request still resolves to published content and renders statically.
+ * Gating on the session rather than on the environment is what lets the
+ * deployed Studio's Presentation tool preview the production site.
+ */
 export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
-  if (!DRAFT_MODE_ENABLED) {
-    return PUBLISHED_FETCH_OPTIONS;
-  }
   const { isEnabled: isDraftMode } = await draftMode();
   if (!isDraftMode) {
-    // Dev without a Presentation session still shows drafts, so draft-only
-    // pages are visible while developing. Stega stays off here.
-    return DRAFTS_FETCH_OPTIONS;
+    return DRAFTS_WITHOUT_SESSION
+      ? DRAFTS_FETCH_OPTIONS
+      : PUBLISHED_FETCH_OPTIONS;
   }
 
   const jar = await cookies();
@@ -70,14 +82,10 @@ export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
 }
 
 /**
- * Perspective/stega for a page route's inner (post-Suspense) component:
- * published in production (stays static), drafts in dev. Must be called outside
- * any `'use cache'` boundary (reads draftMode).
+ * Perspective/stega for a page route's inner (post-Suspense) component. Must be
+ * called outside any `'use cache'` boundary (reads draftMode).
  */
 export async function resolvePageFetchOptions(): Promise<DynamicFetchOptions> {
-  if (!DRAFT_MODE_ENABLED) {
-    return PUBLISHED_FETCH_OPTIONS;
-  }
   return getDynamicFetchOptions();
 }
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -286,13 +286,21 @@
 }
 
 @utility nav-exit {
-  animation-name: nav-exit;
-  /* Drops to 0s without scroll timelines — lands on the settled state. */
-  animation-duration: auto;
+  /* Ignored on a scroll timeline, which drives progress from the range below. */
+  animation-duration: 1ms;
   animation-timing-function: linear;
   animation-fill-mode: both;
   animation-timeline: scroll(root block);
   animation-range: calc(100% - 180px) calc(100% - 20px);
+
+  /* Named only where scroll timelines exist. Elsewhere `animation-timeline` is
+     dropped, so the animation would run once on the document timeline and
+     `fill-mode: both` would hold the bar off screen for good. Unlike
+     `mark-frame` below, these keyframes have a `to`, so there is no safe
+     settled state to fall back on — better to not animate at all. */
+  @supports (animation-timeline: scroll()) {
+    animation-name: nav-exit;
+  }
 }
 
 /* No `to`, so settled is the element's own state and anything ignoring the

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -477,9 +477,19 @@
 
 /* Code blocks (rich-text). Plain, unhighlighted monospace with a line-number
    gutter — no syntax coloring, tabs preserved. */
+.rich-code {
+  /* One inset for both columns: the block padding has to match or number N and
+     line N start on different rows, and the inline inset matches the header's
+     px-3 so the badge, the numbers and the code share one 0.75rem rhythm. */
+  --rich-code-inset-block: 1rem;
+  --rich-code-inset-inline: 0.75rem;
+}
+
 .rich-code-pre {
   margin: 0;
-  padding: 1rem 1.25rem;
+  padding: var(--rich-code-inset-block) var(--rich-code-inset-inline);
+  /* Inherited from .rich-code, so the gutter and the code cannot drift apart. */
+  line-height: inherit;
   /* max-content + min-width keeps the background full-width when lines overflow. */
   width: max-content;
   min-width: 100%;
@@ -491,7 +501,11 @@
 /* Line-number gutter — a fixed column beside the horizontally-scrolling code. */
 .rich-code-gutter {
   flex: none;
-  padding: 1rem 0.75rem;
+  padding: var(--rich-code-inset-block) var(--rich-code-inset-inline);
+  /* Reserve two digits: the column is otherwise content-sized, so a 9-line and
+     a 90-line block would indent their code by different amounts. */
+  min-width: calc(2.5ch + var(--rich-code-inset-inline) * 2);
+  line-height: inherit;
   text-align: right;
   font-variant-numeric: tabular-nums;
   color: color-mix(in oklab, var(--muted-foreground) 60%, transparent);

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -213,8 +213,11 @@
   margin-inline: calc(var(--container-px, 0.5rem) * -1);
 }
 
+/* The one hover wash, shared by nav, the FAQ accordion and blog cards. Any
+ * surface using it must rest on `--background` (white/black), or the wash and
+ * the rest state collapse into each other. */
 @utility hover-surface {
-  @apply hover:bg-zinc-100 dark:hover:bg-zinc-800;
+  @apply hover:bg-zinc-100 dark:hover:bg-zinc-900;
 }
 
 @utility body-text {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -286,20 +286,18 @@
 }
 
 @utility nav-exit {
+  animation-name: nav-exit;
   /* Ignored on a scroll timeline, which drives progress from the range below. */
   animation-duration: 1ms;
   animation-timing-function: linear;
   animation-fill-mode: both;
   animation-timeline: scroll(root block);
   animation-range: calc(100% - 180px) calc(100% - 20px);
+}
 
-  /* Named only where scroll timelines exist. Elsewhere `animation-timeline` is
-     dropped, so the animation would run once on the document timeline and
-     `fill-mode: both` would hold the bar off screen for good. Unlike
-     `mark-frame` below, these keyframes have a `to`, so there is no safe
-     settled state to fall back on — better to not animate at all. */
-  @supports (animation-timeline: scroll()) {
-    animation-name: nav-exit;
+@supports not (animation-timeline: scroll()) {
+  .nav-exit {
+    animation-name: none;
   }
 }
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -274,6 +274,27 @@
   }
 }
 
+/* Slides the navbar out as the footer finishes taking over the screen. Sticky
+   cannot do this on its own while the footer is pinned: a fixed footer adds
+   only `--footer-height` of scroll past the content, so the header's container
+   comes to rest `100vh - --footer-height` below the top and never runs out.
+   Anchored to the end of the document, so it works pinned or in flow. */
+@keyframes nav-exit {
+  to {
+    transform: translateY(-100%);
+  }
+}
+
+@utility nav-exit {
+  animation-name: nav-exit;
+  /* Drops to 0s without scroll timelines — lands on the settled state. */
+  animation-duration: auto;
+  animation-timing-function: linear;
+  animation-fill-mode: both;
+  animation-timeline: scroll(root block);
+  animation-range: calc(100% - 180px) calc(100% - 20px);
+}
+
 /* No `to`, so settled is the element's own state and anything ignoring the
    animation still shows the stroke. User units: SVG % needs `transform-box`. */
 @keyframes mark-frame {


### PR DESCRIPTION
## Problem / Intent

Draft mode was gated to `NODE_ENV === "development"`, so the deployed Studio's Presentation tool could never preview the live site — `<VisualEditing />` never mounted, `<SanityLive>` only ever listened for published content, and no stega was emitted, leaving Presentation with "No matching documents". Alongside that, a review pass turned up four unrelated defects: blog pagination kept the previous page on screen during soft navigation, out-of-range pages returned 200, hover treatments used three different colour pairs, and code blocks rendered their code in a different typeface from their line numbers.

This branch gates draft rendering on the request's session rather than the environment, and fixes the four review items.

## Summary

- **Presentation now works against any deployment.** Drafts render for a request carrying a draft-mode session, which only `/api/presentation-draft` can mint (it validates a Sanity preview secret). Anonymous requests still resolve to published content, so `/` stays statically prerendered and missing routes still return real 404s.
- **Blog pagination re-suspends on soft navigation.** The Suspense boundary is now keyed on `page` + `category`; without a key React reconciled it as the same boundary and kept the previous page's posts _and_ pager mounted for the whole server round trip — the URL read `?page=2` while the grid still showed page 1.
- **Out-of-range blog pages 404.** `?page=3` on a two-page blog previously returned 200 with an empty list.
- **One hover treatment across nav, FAQ and blog cards** — zinc-100 in light, zinc-900 in dark. Nav previously hardcoded zinc-200/zinc-800 in three files and the shared utility used zinc-800.
- **Code blocks render in one typeface.** Tailwind Preflight styled bare `code` with the default mono stack, overriding the family inherited from `<pre>`, so line numbers and code used different fonts and metrics.
- **Footer social icons fade on hover** instead of painting a solid tile behind the icon.
- **Browser tabs show the page title only**, without the site-name suffix; the site name moves to Open Graph `siteName`.

## Core file changes

| File                                                                              | Change                                                                                                                                                                  |
| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `packages/sanity/src/live.ts`                                                     | `DRAFT_MODE_ENABLED` → `DRAFTS_WITHOUT_SESSION`; `getDynamicFetchOptions` now reads `draftMode()` first and only falls back to published when there is no session       |
| `apps/web/src/app/layout.tsx`                                                     | `<SanityLive>` and the Presentation overlay moved into a Suspense-isolated `LivePreviewLayer`, so reading `draftMode()` cannot opt the whole layout out of prerendering |
| `apps/web/src/app/page.tsx`, `[...slug]/page.tsx`, `blog/[slug]/page.tsx`         | Branch on `isDraftMode \|\| DRAFTS_WITHOUT_SESSION` instead of the environment, keeping the published fast path and real `notFound()` for everyone else                 |
| `apps/web/src/app/blog/page.tsx`                                                  | Keyed inner Suspense boundary; `parseBlogPageParam`; `assertBlogPageInRange` called from `generateMetadata` so an out-of-range page 404s before the status is committed |
| `packages/ui/src/styles/globals.css`                                              | `hover-surface` dark hover zinc-800 → zinc-900; `.rich-code` gains shared inset variables, inherited `line-height` and a two-digit gutter `min-width`                   |
| `packages/sanity-blocks/src/internal/code-block.tsx`                              | `font-mono` on `<code>` so the utilities layer beats Preflight                                                                                                          |
| `packages/sanity-blocks/src/faq-accordion/index.tsx`                              | Resting surface back to `bg-background` so the new hover is visible; `duration-300` → `animation-duration-300` so the entrance no longer stretches the hover fade       |
| `apps/web/src/components/navbar.tsx`, `mobile-menu.tsx`, `elements/menu-link.tsx` | Hardcoded `hover:bg-zinc-200 dark:hover:bg-zinc-800` replaced with the shared `hover-surface` utility                                                                   |
| `apps/web/src/components/footer.tsx`                                              | Social icons drop the solid hover tile for an opacity fade                                                                                                              |
| `apps/web/src/lib/seo.ts`                                                         | Page title only, no site-name suffix; `siteName` added to `openGraph`                                                                                                   |

## Verification

- [x] `pnpm check-types` — 8/8
- [x] `pnpm lint` — 9/9
- [x] `pnpm format:check` — 9/9
- [x] `pnpm test` — 213 tests, 26 files
- [x] `pnpm build:web` — `/` still `○ (Static)`; `/[...slug]`, `/blog`, `/blog/[slug]` still `◐ (Partial Prerender)`
- [x] Anonymous production request to a missing route returns a real **404**, not a soft one
- [x] `/api/presentation-draft` returns **401** with no secret and with a bogus secret
- [x] On `/blog`, click "Next page" — the grid _and_ the pager both move to page 2. A/B against an instrumented build: unkeyed held page 1 for **4081ms** with the pager stuck on "1"; keyed drops to **41ms** and shows the skeleton
- [x] `/blog?page=3` returns 404 for a crawler user-agent
- [x] Hover a nav link, an FAQ item and a blog card in both themes — all resolve to `#f4f4f5` light / `#18181b` dark


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved draft and live preview behavior, including reliable production preview sessions.
  - Added smoother navigation transitions as visitors approach the end of a page.
- **Bug Fixes**
  - Published pages and blog posts now return accurate 404 pages when content is unavailable.
  - Blog navigation validates page numbers and categories to prevent invalid content displays.
- **Improvements**
  - Updated metadata and refined navigation, menus, footer, FAQ, code styling, dark-mode hover states, and reduced-motion support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->