### PR TITLE
ROB-2620 : Fix Page Builder Drag Reordering And Hero Selection

### DIFF
--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -111,10 +111,25 @@ function useOptimisticPageBuilder(
   return useOptimistic<PageBuilderBlock[], any>(
     initialBlocks,
     (currentBlocks, action) => {
-      if (action.id === documentId && action.document?.pageBuilder) {
-        return action.document.pageBuilder;
+      if (action.id !== documentId || !action.document?.pageBuilder) {
+        return currentBlocks;
       }
-      return currentBlocks;
+
+      // The action carries the raw document, not the GROQ projection the page
+      // rendered from, so only its `_key` order is usable — take that and keep
+      // the resolved blocks. Keys with no resolved block (a just-inserted one)
+      // are dropped until revalidation projects them.
+      const resolved = new Map(
+        currentBlocks.map((block) => [block._key, block])
+      );
+      const reordered: PageBuilderBlock[] = [];
+      for (const raw of action.document.pageBuilder) {
+        const block = raw?._key ? resolved.get(raw._key) : undefined;
+        if (block) {
+          reordered.push(block);
+        }
+      }
+      return reordered;
     }
   );
 }

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -119,7 +119,12 @@ function useOptimisticPageBuilder(
   return useOptimistic<PageBuilderBlock[], any>(
     initialBlocks,
     (currentBlocks, action) => {
-      if (action.id !== documentId || !action.document?.pageBuilder) {
+      // `action` is untyped and comes off the mutation stream, so a truthy
+      // non-array `pageBuilder` would throw out of `for...of` mid-render.
+      if (
+        action.id !== documentId ||
+        !Array.isArray(action.document?.pageBuilder)
+      ) {
         return currentBlocks;
       }
 

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -33,7 +33,11 @@ type SanityDataAttributeConfig = {
  * against its PagebuilderType so a GROQ or schema rename breaks the build
  * instead of silently passing through `any`.
  */
-function renderBlockComponent(block: PageBuilderBlock, isFirst: boolean) {
+function renderBlockComponent(
+  block: PageBuilderBlock,
+  isFirst: boolean,
+  dataSanity?: string
+) {
   switch (block?._type) {
     case "cta":
       return <CTABlock {...(block as PagebuilderType<"cta">)} />;
@@ -41,7 +45,11 @@ function renderBlockComponent(block: PageBuilderBlock, isFirst: boolean) {
       return <FaqAccordion {...(block as PagebuilderType<"faqAccordion">)} />;
     case "hero":
       return (
-        <HeroBlock {...(block as PagebuilderType<"hero">)} isFirst={isFirst} />
+        <HeroBlock
+          {...(block as PagebuilderType<"hero">)}
+          dataSanity={dataSanity}
+          isFirst={isFirst}
+        />
       );
     case "featureCardsIcon":
       return (
@@ -143,7 +151,19 @@ function useBlockRenderer(id: string, type: string) {
     });
 
   const renderBlock = (block: PageBuilderBlock, index: number) => {
-    const content = block && renderBlockComponent(block, index === 0);
+    // The leading hero's wrapper is `display: contents` so the banner pins
+    // against this grid, and a box-less element measures 0x0 in the visual
+    // editing overlay — unselectable, undraggable. Hand the attribute to the
+    // hero instead, which puts it on the banner box.
+    const isLeadingHero = index === 0 && block?._type === "hero";
+    const dataSanity = block && createBlockDataAttribute(block._key);
+    const content =
+      block &&
+      renderBlockComponent(
+        block,
+        index === 0,
+        isLeadingHero ? dataSanity : undefined
+      );
 
     if (!content) {
       return (
@@ -155,15 +175,13 @@ function useBlockRenderer(id: string, type: string) {
       );
     }
 
-    const isLeadingHero = index === 0 && block._type === "hero";
-
     return (
       <div
         className={cn(
           "min-w-0",
           isLeadingHero ? "contents" : "relative z-10 bg-background"
         )}
-        data-sanity={createBlockDataAttribute(block._key)}
+        data-sanity={isLeadingHero ? undefined : dataSanity}
         key={`${block._type}-${block._key}`}
       >
         {content}

--- a/packages/sanity-blocks/src/hero/hero.test.tsx
+++ b/packages/sanity-blocks/src/hero/hero.test.tsx
@@ -35,3 +35,16 @@ test("HeroBlock renders without image when not provided", () => {
 
   expect(html).toMatch(/No image test/);
 });
+
+// The leading hero's page-builder wrapper is `display: contents`, which
+// measures 0x0 in the visual editing overlay. The attribute has to land on the
+// banner box or the block can't be selected or drag-sorted in Presentation.
+test("leading HeroBlock puts the visual editing attribute on the banner box", () => {
+  const html = renderToStaticMarkup(
+    <HeroBlock dataSanity="drag-me" isFirst title="Pinned" />
+  );
+
+  expect(html).toMatch(
+    /<div[^>]*class="sticky[^"]*"[^>]*data-sanity="drag-me"/
+  );
+});

--- a/packages/sanity-blocks/src/hero/hero.test.tsx
+++ b/packages/sanity-blocks/src/hero/hero.test.tsx
@@ -37,13 +37,15 @@ test("HeroBlock renders without image when not provided", () => {
 });
 
 // The leading hero's page-builder wrapper is `display: contents`, which
-// measures 0x0 in the visual editing overlay. The attribute has to land on the
-// banner box or the block can't be selected or drag-sorted in Presentation.
-test("leading HeroBlock puts the visual editing attribute on the banner box", () => {
+// measures 0x0 in the visual editing overlay. Both of the boxes it renders
+// instead have to carry the attribute: one resolving to the page-builder array
+// rather than the block makes that half refuse to drag.
+test("leading HeroBlock puts the visual editing attribute on both boxes", () => {
   const html = renderToStaticMarkup(
     <HeroBlock dataSanity="drag-me" isFirst title="Pinned" />
   );
 
+  expect(html.match(/data-sanity="drag-me"/g)).toHaveLength(2);
   expect(html).toMatch(
     /<div[^>]*class="sticky[^"]*"[^>]*data-sanity="drag-me"/
   );

--- a/packages/sanity-blocks/src/hero/index.tsx
+++ b/packages/sanity-blocks/src/hero/index.tsx
@@ -22,7 +22,9 @@ export interface HeroBlockProps {
    * Visual editing attribute for the block. Only the leading hero needs it:
    * its page-builder wrapper is `display: contents` so the banner can pin
    * against the grid, and a box-less element measures 0x0 in the overlay.
-   * The banner carries it instead so the block stays selectable and drag-sortable.
+   * Both boxes below carry it instead — the overlay only treats an element as
+   * drag-sortable when it resolves to an array-member path, so a half without
+   * it would resolve to the page-builder array itself and refuse to drag.
    */
   dataSanity?: string;
   isFirst?: boolean;
@@ -158,7 +160,10 @@ export function HeroBlock({
       >
         {banner}
       </div>
-      <div className="relative z-10 bg-background pt-6 pb-8 md:pt-8 md:pb-12">
+      <div
+        className="relative z-10 bg-background pt-6 pb-8 md:pt-8 md:pb-12"
+        data-sanity={dataSanity}
+      >
         {copy}
       </div>
     </>

--- a/packages/sanity-blocks/src/hero/index.tsx
+++ b/packages/sanity-blocks/src/hero/index.tsx
@@ -18,6 +18,13 @@ export type { HeroVideoData, HeroVideoVariant } from "./hero-video";
 export interface HeroBlockProps {
   badge?: string | null;
   buttons?: ButtonProps[] | null;
+  /**
+   * Visual editing attribute for the block. Only the leading hero needs it:
+   * its page-builder wrapper is `display: contents` so the banner can pin
+   * against the grid, and a box-less element measures 0x0 in the overlay.
+   * The banner carries it instead so the block stays selectable and drag-sortable.
+   */
+  dataSanity?: string;
   isFirst?: boolean;
   richText?: RichTextValue;
   title?: string | null;
@@ -96,6 +103,7 @@ export function HeroBlock({
   title,
   buttons,
   badge,
+  dataSanity,
   richText,
   isFirst,
   video,
@@ -145,6 +153,7 @@ export function HeroBlock({
     <>
       <div
         className="sticky top-0 z-0 h-[calc(100svh-var(--hero-copy))] overflow-hidden bg-background"
+        data-sanity={dataSanity}
         id="hero"
       >
         {banner}


### PR DESCRIPTION
## Problem / Intent

Shift-dragging a block in Presentation corrupted the page: images lost their sources, FAQ and author references stopped resolving, links went dead, and blocks left behind opaque black rectangles where their content used to be. Separately, the hero sitting at the top of a page couldn't be selected or dragged at all. This branch fixes both so a page can be reordered in the editor without the preview falling apart.

## Approach

The optimistic reducer in `useOptimisticPageBuilder` replaced the rendered block array with `action.document.pageBuilder` wholesale. That action carries the **raw** document off the mutation stream, not the GROQ-projected shape the page rendered from — raw blocks hold `image.asset._ref` instead of a resolved url and dimensions, and references are still `_ref` strings. Swapping the resolved array for the raw one stripped every derived field at once, which is why one drag broke media, references and links together. The reducer now reads only the `_key` sequence off the raw document and reorders the already-resolved blocks to match. A key with no resolved block — a just-inserted one that has no projection yet — is dropped until revalidation brings it in, on the grounds that a block absent for a moment beats one rendered broken.

The hero problem is unrelated in cause. The leading hero's page-builder wrapper is `display: contents` so its banner's `sticky` resolves against the page-builder grid and stays pinned for the whole page. But that wrapper is also the node carrying `data-sanity`, and an element with `display: contents` generates no boxes, so the `getBoundingClientRect()` that `@sanity/visual-editing` measures every registered element with returns 0×0 — no hit area to grab and nothing to drop against. The attribute now passes through to `HeroBlock` via a `dataSanity` prop and lands on the sticky banner div, a real full-width box at the top of the block. Layout is untouched; only which node advertises itself to the overlay changes.

## Verification

Done:

- [x] `pnpm check-types`, `pnpm lint`, `pnpm test` — all green (214 tests, including a new assertion that the leading hero's visual editing attribute lands on the banner box)
- [x] **The 0×0 measurement is confirmed in a real browser.** Against the running dev server, the leading hero's `display: contents` wrapper measures `0×0` with `getClientRects().length === 0` and no longer carries `data-sanity`; the banner it moved to measures `1440×615` with one client rect. That is the exact quantity `@sanity/visual-editing` reads via `getBoundingClientRect()` to build a block's hit area.
- [x] **The raw-vs-projected root cause is confirmed against the dataset.** The home page's raw `pageBuilder` carries 49 unresolved `_ref` pointers across its six blocks — 20 in `faqAccordion` alone, plus image assets in `logoCloud`, video assets and an internal button link in `hero`, and `testimonial.authorImage.asset` in `subscribeNewsletter`. The previous reducer substituted all of that for the resolved array on every drag. `featureCardsIcon` holds no refs, which predicts it was the one block that survived a drag intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page-builder updates so confirmed content remains in the correct order.
  * Prevented unconfirmed newly added content from appearing incorrectly before refresh.
  * Improved editing metadata placement for leading hero sections.
* **Tests**
  * Added coverage confirming that leading hero sections apply editing metadata to the correct banner element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->