### PR TITLE
Restore Presentation Editing For Navbar And Footer

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import "@workspace/ui/globals.css";
 
 import {
-  DRAFTS_WITHOUT_SESSION,
   type DynamicFetchOptions,
   getDynamicFetchOptions,
   SanityLive,
@@ -40,10 +39,6 @@ export default async function RootLayout({
 }>) {
   preconnect("https://cdn.sanity.io");
   prefetchDNS("https://cdn.sanity.io");
-  // In local dev, nav/footer follow drafts too (like page content), so draft
-  // navbar/footer/settings edits are visible without a Presentation session.
-  // Production stays static published.
-  const showDrafts = DRAFTS_WITHOUT_SESSION;
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -58,27 +53,22 @@ export default async function RootLayout({
             id="page-shell"
             style={{ marginBottom: "var(--footer-height)" }}
           >
-            {showDrafts ? (
-              <Suspense
-                fallback={<Navbar navbarData={null} settingsData={null} />}
-              >
-                <DynamicNavbar />
-              </Suspense>
-            ) : (
-              <CachedNavbar perspective="published" stega={false} />
-            )}
+            {/* Session-gated, not environment-gated, so the deployed Studio can
+                edit the nav; the published fallback keeps real content in the
+                static shell. */}
+            <Suspense fallback={<PublishedNavbar />}>
+              <DynamicNavbar />
+            </Suspense>
             <div className="relative z-10 min-h-dvh bg-background pt-16 lg:-mt-16">
               {children}
             </div>
           </div>
           <StickyFooter>
-            {showDrafts ? (
-              <Suspense fallback={null}>
-                <DynamicFooter />
-              </Suspense>
-            ) : (
-              <CachedFooter perspective="published" stega={false} />
-            )}
+            <Suspense
+              fallback={<CachedFooter perspective="published" stega={false} />}
+            >
+              <DynamicFooter />
+            </Suspense>
           </StickyFooter>
           {/* Reads draftMode(), so it must stay behind Suspense — otherwise the
               whole layout opts out of prerendering for every visitor. */}
@@ -117,6 +107,17 @@ async function LivePreviewLayer() {
 async function DynamicNavbar() {
   const { perspective, stega } = await getDynamicFetchOptions();
   return <CachedNavbar perspective={perspective} stega={stega} />;
+}
+
+/** Static shell for the nav. A Suspense fallback renders in the parent, so it
+ * may only await cached data — `getGithubStars` memoizes at runtime, so the
+ * count arrives with DynamicNavbar instead. */
+async function PublishedNavbar() {
+  const { navbarData, settingsData } = await getNavigationData({
+    perspective: "published",
+    stega: false,
+  });
+  return <Navbar navbarData={navbarData} settingsData={settingsData} />;
 }
 
 async function CachedNavbar({ perspective, stega }: DynamicFetchOptions) {


### PR DESCRIPTION
## Problem

Navbar, footer and settings were not editable in the deployed Studio's Presentation tool. Clicking them did nothing, and they never appeared under "Documents on this page" — while page-builder content on the same page worked fine.

Two things make an element editable in Presentation: stega (the invisible markers that tell the overlay which document and field a value came from) or an explicit `createDataAttribute`. The layout had neither. It rendered both slots with `stega={false}`, and `createDataAttribute` is only used in `pagebuilder.tsx`.

The gate deciding that was:

```ts
const showDrafts = DRAFTS_WITHOUT_SESSION;   // process.env.NODE_ENV === "development"
```

So the question being asked was *"am I running locally?"* rather than *"is this request inside Presentation?"* — and production never qualified.

## Cause

`ee11ff5` (29 Jul) swapped the gate from the draft-mode session to the environment:

```diff
-{isDraftMode || previewForceDrafts ? (
+{showDrafts ? (
   <DynamicNavbar />
```

Before that, the layout gated on `isDraftMode`, so nav and footer were editable in Presentation anywhere — that had been true since the split was introduced in `e1e4a7f`, and before the split existed they were simply always dynamic.

`1d7c929` (5 Aug) restored the session check for page content and for the Presentation overlay itself, with a comment stating the principle:

> Gating on the session rather than on the environment is what lets the deployed Studio's Presentation tool preview the production site.

It just never got applied to the layout. This finishes that migration.

## Change

Both slots now always render the dynamic component behind Suspense, with a published shell as the fallback. `DynamicNavbar` / `DynamicFooter` already call `getDynamicFetchOptions()`, which resolves the session on its own — the environment check was the only thing in the way.

```tsx
<Suspense fallback={<PublishedNavbar />}>
  <DynamicNavbar />
</Suspense>
```

Two constraints shaped this:

- **The `draftMode()` read stays inside the boundary.** Reading it in the layout body would opt the whole layout out of prerendering for every visitor — the same trap the existing `LivePreviewLayer` comment warns about.
- **A Suspense fallback renders in the parent, so it may only await cached data.** The first attempt used `CachedNavbar` directly as the fallback and blocked the route with `Uncached data or connection() was accessed outside of <Suspense>` — `getGithubStars` memoizes at runtime via `performance.now()` and a module-level `Map`. `PublishedNavbar` awaits only `getNavigationData` (which is `"use cache"`); the star count arrives with `DynamicNavbar`. `CachedFooter` is already `"use cache"`, so it serves as its own fallback.

Using a real published shell rather than `null` or an empty nav keeps actual content in the static HTML, so anonymous visitors see no flash or layout shift.

## Behaviour

| | before | after |
| --- | --- | --- |
| local dev, no session | drafts | drafts (unchanged) |
| local dev, in Presentation | editable | editable (unchanged) |
| production, no session | published, static | published, static (unchanged) |
| production, in Presentation | **not editable** | **editable** |

Only the last row changes. Anonymous production traffic still gets published content from a prerendered shell.

## Verification

- `tsc --noEmit` and `biome lint` clean
- `pnpm build:web` succeeds with an unchanged route table — `/` still `○ (Static)`, `[...slug]` and `blog/*` still partial-prerender
- Nav markup confirmed present in the prerendered `apps/web/.next/server/app/index.html`
- Dev server returns 200 on `/` and `/?sanity-preview-perspective=drafts` with no blocking-route errors in the log

Not verified: click-to-edit in the deployed Presentation tool — that needs this deployed. The logic now matches what page content already does.

## Related, not fixed here

`packages/sanity/src/client.ts:14` sets `stega: { enabled: env.NODE_ENV === "development" }` — the same environment-not-session shape. It isn't breaking anything today because per-call `stega` overrides it, but it's misleading and worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigation and footer loading behavior for a more consistent published-site experience.
  * Added published-content fallbacks while dynamic navigation and footer content loads.
  * Removed draft visibility differences based on session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->