### PR TITLE
fix(hero): size the background to the device and the connection

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -39,12 +39,6 @@ export default async function RootLayout({
 }>) {
   preconnect("https://cdn.sanity.io");
   prefetchDNS("https://cdn.sanity.io");
-  // Mux serves the manifest from stream and the poster from image, both on
-  // the critical path once a page carries a clip.
-  preconnect("https://stream.mux.com");
-  prefetchDNS("https://stream.mux.com");
-  preconnect("https://image.mux.com");
-  prefetchDNS("https://image.mux.com");
   return (
     <html lang="en" suppressHydrationWarning>
       <body

--- a/packages/sanity-blocks/src/hero/hero-video.tsx
+++ b/packages/sanity-blocks/src/hero/hero-video.tsx
@@ -67,24 +67,37 @@ function sourceKeyOf(variant?: HeroVideoVariant | null): string | null {
   );
 }
 
+/** The resolutions every path picks between. */
+export type DeliveryRung = "1080p" | "720p" | "480p";
+
+type Connection = { effectiveType?: string; saveData?: boolean };
+
 /**
- * Whether this viewport should get the smaller clip. The `media` attribute on
- * `<source>` was dropped from the spec and Chrome ignores it, so picking in JS
- * is the only portable option.
+ * The rendition for this screen and connection.
+ *
+ * Split from the globals so it is testable: `deliveryRung` reads them, this
+ * decides. `saveData` and `effectiveType` are Chromium-only, so Safari and
+ * Firefox fall through to the width, which is the answer they had before.
  */
-function useIsCompactViewport(): boolean {
-  const [isCompact, setIsCompact] = useState(false);
+export function rungFor(width: number, connection?: Connection): DeliveryRung {
+  if (
+    connection?.saveData ||
+    /(^|-)2g$/.test(connection?.effectiveType ?? "")
+  ) {
+    return "480p";
+  }
+  return width >= 1280 ? "1080p" : "720p";
+}
 
-  useEffect(() => {
-    const query = window.matchMedia("(max-width: 1279px)");
-    setIsCompact(query.matches);
-    const onChange = (event: MediaQueryListEvent) =>
-      setIsCompact(event.matches);
-    query.addEventListener("change", onChange);
-    return () => query.removeEventListener("change", onChange);
-  }, []);
-
-  return isCompact;
+/**
+ * Read once, at mount. Deliberately not reactive: `key` is the source URL, so
+ * re-picking on a resize would remount the element and re-download the clip —
+ * worse than leaving an already-buffered loop alone. Safe to call during render
+ * because `HeroVideo` renders nothing until it has mounted.
+ */
+function deliveryRung(): DeliveryRung {
+  const { connection } = navigator as Navigator & { connection?: Connection };
+  return rungFor(window.innerWidth, connection);
 }
 
 /**
@@ -92,10 +105,11 @@ function useIsCompactViewport(): boolean {
  * that cannot decode it drops to the desktop HEVC, still the smallest file in
  * the set.
  */
-function pickSources(variant: HeroVideoVariant | null, isCompact: boolean) {
-  const webm = isCompact
-    ? (variant?.mobileWebm ?? variant?.webm)
-    : variant?.webm;
+function pickSources(variant: HeroVideoVariant | null, rung: DeliveryRung) {
+  // Only two encodes exist, so anything below the desktop rung takes the
+  // smaller one — including a wide screen on a metered connection.
+  const webm =
+    rung === "1080p" ? variant?.webm : (variant?.mobileWebm ?? variant?.webm);
   return {
     hevc: stegaClean(variant?.hevc) ?? undefined,
     webm: stegaClean(webm) ?? undefined,
@@ -126,10 +140,17 @@ type BackgroundProps = Readonly<{
 
 /** Mux: one upload, an adaptive ladder, and hls.js to drive it. */
 function MuxBackground({ className, onReady, variant }: BackgroundProps) {
+  const rung = deliveryRung();
   const playbackId = muxPlaybackId(variant.mux);
   if (!playbackId) {
     return null;
   }
+
+  // `maxResolution` bottoms out at 720p, so a thin link gets the ladder
+  // instead: releasing `desc` lets ABR settle on 480p or 270p itself. Pinning
+  // the top rung is right everywhere else, since a short loop replays from
+  // buffer and so never steps up on its own.
+  const thin = rung === "480p";
 
   return (
     <MuxVideo
@@ -148,17 +169,13 @@ function MuxBackground({ className, onReady, variant }: BackgroundProps) {
       disableTracking
       key={playbackId}
       loop
-      // A short loop replays from buffer, so ABR never steps up from whatever
-      // the first segment picked. Capping the ladder high-first pins it to
-      // 1080p immediately. Not higher: Mux ships H.264, and 2160p costs
-      // several times the bytes for a background nobody is studying.
-      maxResolution="1080p"
+      maxResolution={thin ? "720p" : rung}
       muted
       onCanPlay={onReady}
       playbackId={playbackId}
       playsInline
       preload="auto"
-      renditionOrder="desc"
+      renditionOrder={thin ? undefined : "desc"}
       streamType="on-demand"
       tabIndex={-1}
     />
@@ -178,9 +195,9 @@ function MuxBackground({ className, onReady, variant }: BackgroundProps) {
  * matching what the hand-encoded set does across the same breakpoint.
  */
 function MuxMp4Background({ className, onReady, variant }: BackgroundProps) {
-  const isCompactViewport = useIsCompactViewport();
+  const rung = deliveryRung();
   const playbackId = muxPlaybackId(variant.mux);
-  const src = muxMp4Url(playbackId, isCompactViewport ? "720p" : "1080p");
+  const src = muxMp4Url(playbackId, rung);
   if (!src) {
     return null;
   }
@@ -206,8 +223,8 @@ function MuxMp4Background({ className, onReady, variant }: BackgroundProps) {
 
 /** Sanity: the hand-encoded set, served straight off the asset CDN. */
 function FileBackground({ className, onReady, variant }: BackgroundProps) {
-  const isCompactViewport = useIsCompactViewport();
-  const sources = pickSources(variant, isCompactViewport);
+  const rung = deliveryRung();
+  const sources = pickSources(variant, rung);
   if (!(sources.webm || sources.hevc)) {
     return null;
   }

--- a/packages/sanity-blocks/src/hero/media-type.test.ts
+++ b/packages/sanity-blocks/src/hero/media-type.test.ts
@@ -1,3 +1,4 @@
+import { rungFor } from "@workspace/sanity-blocks/hero/hero-video";
 import {
   isMuxPath,
   mediaTypeOf,
@@ -54,4 +55,17 @@ test("the progressive-MP4 path is recognised and counts as Mux", () => {
 test("mux-mp4 is never inferred, only chosen", () => {
   expect(mediaTypeOf({ mux: READY_MUX })).toBe("mux");
   expect(mediaTypeOf({})).toBe("sanity");
+});
+
+test("the rung follows the width, and a thin link overrides it", () => {
+  expect(rungFor(1440)).toBe("1080p");
+  expect(rungFor(1280)).toBe("1080p");
+  expect(rungFor(390)).toBe("720p");
+  // Save-Data and 2g both mean "not the big one", whatever the screen says.
+  expect(rungFor(1440, { saveData: true })).toBe("480p");
+  expect(rungFor(1440, { effectiveType: "slow-2g" })).toBe("480p");
+  expect(rungFor(1440, { effectiveType: "2g" })).toBe("480p");
+  // 3g and 4g are not thin enough to give up resolution for.
+  expect(rungFor(1440, { effectiveType: "4g" })).toBe("1080p");
+  expect(rungFor(390, { effectiveType: "3g" })).toBe("720p");
 });


### PR DESCRIPTION
The rung was fixed at 1080p on every path. `maxResolution` and `renditionOrder` are device-independent props, and `@mux/playback-core` ships `capLevelToPlayerSize: false` — so a phone got the desktop rendition: **1704×1080 painted into a 485×333 box**, and **16.2s** to play through on a 1.6 Mbps link where the file path took 6.0s.

`rungFor(width, connection)` returns the rendition. All three delivery paths call it.

| link / viewport | rung | dark hero |
|---|---|---|
| desktop | 1080p | 2.92 MB |
| phone | 720p | 1.62 MB |
| `saveData` or 2g | 480p | 0.92 MB |

Read once at mount, deliberately not reactive: `key` is the source URL, so re-picking on a resize would remount the element and re-download a clip that is already buffered.

`maxResolution` bottoms out at 720p, so a thin link cannot be capped lower. There `renditionOrder` is released instead and ABR settles on the 480p or 270p rung itself — stepping *down* matters more than never stepping up when the link is the constraint. The progressive path has no ladder to fall back on, so it got a 480p static rendition on both hero assets.

Also drops the Mux preconnects from the root layout. They fired on every page including ones with no Mux content, and by the time the adaptive path asks for a manifest — after hydration and a 194 KB chunk — an idle preconnect has usually been reaped anyway.

## Verification

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm format:check`
- [x] `pnpm --filter @workspace/sanity-blocks test` — 267 passing
- [x] `pnpm build:web`
- [x] All six static renditions serve 200: 1080p / 720p / 480p on both hero assets

Byte figures are decimal MB, measured off the wire.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved hero video delivery by adapting quality to screen size and network conditions.
  * Added lower-resolution options for slower connections and data-saving mode.
  * Removed unnecessary connection hints for video and image services.
* **Bug Fixes**
  * Reduced bandwidth usage and improved video loading on constrained networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->