### PR TITLE
fix: resolve tailwind callouts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "css.lint.unknownAtRules": "ignore",
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,
   "editor.codeActionsOnSave": {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -245,7 +245,7 @@
 /* Overrides Tailwind's `container`. Inset defaults to 8px via a fallback var,
  * so [--container-px:…] can override it per instance. */
 @utility container {
-  @apply mx-auto w-full max-w-[90rem] px-[var(--container-px,0.5rem)];
+  @apply mx-auto w-full max-w-360 px-(--container-px,0.5rem);
 }
 
 /* Cancels the container's padding (hardcoding it caused mobile scroll). */


### PR DESCRIPTION
## Description

This PR resolves Tailwind-related editor callouts by aligning our custom `container` utility with the Tailwind v4 syntax used in the repo and by quieting false-positive CSS linting in VS Code.

It updates `packages/ui/src/styles/globals.css` so the `container` utility uses Tailwind shorthand for the max width and CSS variable-based padding, and adds a workspace setting to ignore unknown CSS at-rules like `@utility` and `@plugin`.


## Type of change

- [ ] Feature
- [X] Fix
- [ ] Refactor
- [ ] Documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the shared container styling to use the latest spacing token format while preserving its existing width, alignment, and padding behavior.

* **Chores**
  * Adjusted workspace CSS linting settings to prevent warnings for supported custom at-rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->