### PR TITLE
fix: logger set to read only 

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,5 +1,5 @@
 export class Logger {
-  private context: string;
+  private readonly context: string;
 
   constructor(context: string) {
     this.context = context;


### PR DESCRIPTION
## Description

Marks the logger context as `readonly` so it can only be set during construction. This makes the `Logger` class intent clearer and prevents accidental reassignment later without changing the runtime logging behavior.

## Type of change

- [ ] Feature
- [X] Fix
- [ ] Refactor
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved logger context stability by preventing it from being changed after initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->