### PR TITLE
fix: resolve false "Cannot find name 'process'" in packages/env

### DIFF
--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@workspace/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Description

`packages/env/src/client.ts` and `server.ts` reference `process.env` directly, relying on TypeScript's ambient `@types` auto-discovery to pull in `@types/node` (no `types` compiler option is set, so TS walks `node_modules/@types` looking for anything to include).

That auto-discovery is sensitive to which TypeScript binary is actually doing the resolving. In VS Code specifically, if the editor's TS language server ends up running a different TypeScript version than the one pinned in this repo (e.g. its own bundled copy instead of the workspace's), ambient discovery can silently fail to pick up `@types/node` even though `tsc` against the exact same `tsconfig.json` compiles clean from the CLI. The practical symptom: a persistent `Cannot find name 'process'. ts(2591)` squiggle in the editor on every project scaffolded from this template, that survives "Restart TS Server" and manually reselecting the workspace TypeScript version, because the project's config was never wrong — the version doing the resolving was.

This adds an explicit `"types": ["node"]` to `packages/env/tsconfig.json`, so `@types/node` is loaded via a direct, unambiguous lookup instead of depending on ambient auto-discovery behavior that can vary across TypeScript versions.

## Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Documentation

## Screenshots (if applicable)

N/A — config-only change.

## Testing

- `pnpm --filter env check-types` (`tsc --noEmit`) passes before and after —  confirms the change doesn't alter CLI type-checking behavior.
- Verified in VS Code: with the editor's TS server running a TypeScript  version other than the one pinned in this repo (reproducible by checking  `Output > TypeScript` — `Using tsserver from: ...`), `process` was  unresolved in `client.ts`/`server.ts` before this change and resolves  correctly after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript compilation support for Node.js-specific types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->