### PR TITLE
refactor: simplify footer theme toggle indicator positioning

### DIFF
--- a/apps/web/src/components/footer-theme-toggle.tsx
+++ b/apps/web/src/components/footer-theme-toggle.tsx
@@ -3,19 +3,12 @@
 import { cn } from "@workspace/tailwind-config/utils";
 import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useSyncExternalStore } from "react";
+import { useRef, useSyncExternalStore } from "react";
 
 const THEMES = [
   { value: "light", label: "Light", Icon: Sun },
   { value: "system", label: "System", Icon: Monitor },
   { value: "dark", label: "Dark", Icon: Moon },
-] as const;
-
-// Segments are equal width, so the pill slides by multiples of its own width.
-const PILL_OFFSETS = [
-  "translate-x-0",
-  "translate-x-full",
-  "translate-x-[200%]",
 ] as const;
 
 // theme is client-only; render neutral until hydrated.
@@ -32,23 +25,29 @@ const useMounted = () =>
 export function FooterThemeToggle() {
   const { theme, setTheme } = useTheme();
   const mounted = useMounted();
+  const pillRef = useRef<HTMLSpanElement | null>(null);
 
-  const activeIndex = Math.max(
-    0,
-    THEMES.findIndex(({ value }) => value === theme)
-  );
+  // Ref on the active button, so it runs before paint whenever active moves.
+  const placePill = (el: HTMLButtonElement | null) => {
+    const pill = pillRef.current;
+    if (el && pill) {
+      pill.style.left = `${el.offsetLeft}px`;
+      pill.style.width = `${el.offsetWidth}px`;
+    }
+  };
 
   return (
     <div className="relative flex items-center rounded-full border border-accent-green-foreground/40">
       <span
         aria-hidden="true"
         className={cn(
-          "-translate-y-1/2 absolute top-1/2 left-0 h-8 w-1/3 rounded-full bg-accent-green-foreground",
+          "-translate-y-1/2 absolute top-1/2 h-8 rounded-full bg-accent-green-foreground",
           // `!` beats the transition kill from `disableTransitionOnChange`.
-          "motion-safe:transition-transform! motion-safe:duration-300! motion-safe:ease-[var(--ease-spring)]!",
-          // hidden until mounted so the pill doesn't fly in from the left.
-          mounted ? PILL_OFFSETS[activeIndex] : "hidden"
+          "motion-safe:transition-[left,width]! motion-safe:duration-300! motion-safe:ease-[var(--ease-spring)]!",
+          // hidden until placed so the pill doesn't fly in from the left.
+          !mounted && "hidden"
         )}
+        ref={pillRef}
       />
       {THEMES.map(({ value, label, Icon }) => {
         const active = mounted && theme === value;
@@ -64,6 +63,7 @@ export function FooterThemeToggle() {
             )}
             key={value}
             onClick={() => setTheme(value)}
+            ref={active ? placePill : undefined}
             type="button"
           >
             <Icon

--- a/apps/web/src/components/footer-theme-toggle.tsx
+++ b/apps/web/src/components/footer-theme-toggle.tsx
@@ -37,7 +37,7 @@ export function FooterThemeToggle() {
   };
 
   return (
-    <div className="relative flex items-center rounded-full border border-accent-green-foreground/40">
+    <div className="relative grid grid-flow-col items-center rounded-full border border-accent-green-foreground/40">
       <span
         aria-hidden="true"
         className={cn(

--- a/apps/web/src/components/footer-theme-toggle.tsx
+++ b/apps/web/src/components/footer-theme-toggle.tsx
@@ -3,16 +3,7 @@
 import { cn } from "@workspace/tailwind-config/utils";
 import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-
-const useIsomorphicLayoutEffect =
-  typeof window === "undefined" ? useEffect : useLayoutEffect;
+import { useSyncExternalStore } from "react";
 
 const THEMES = [
   { value: "light", label: "Light", Icon: Sun },
@@ -20,55 +11,46 @@ const THEMES = [
   { value: "dark", label: "Dark", Icon: Moon },
 ] as const;
 
+// Segments are equal width, so the pill slides by multiples of its own width.
+const PILL_OFFSETS = [
+  "translate-x-0",
+  "translate-x-full",
+  "translate-x-[200%]",
+] as const;
+
+// theme is client-only; render neutral until hydrated.
+const emptySubscribe = () => () => {
+  // nothing to unsubscribe
+};
+const useMounted = () =>
+  useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+
 export function FooterThemeToggle() {
   const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const pillRef = useRef<HTMLSpanElement | null>(null);
+  const mounted = useMounted();
 
   const activeIndex = Math.max(
     0,
     THEMES.findIndex(({ value }) => value === theme)
   );
 
-  const positionPill = useCallback((index: number) => {
-    const el = buttonRefs.current[index];
-    const container = containerRef.current;
-    const pill = pillRef.current;
-    if (!(el && container && pill)) {
-      return;
-    }
-    pill.style.left = `${el.offsetLeft}px`;
-    pill.style.right = `${container.clientWidth - (el.offsetLeft + el.offsetWidth)}px`;
-  }, []);
-
-  // Before paint, so the pill is already under the active button on the frame
-  // it fades in on — and on every later theme change, so it never lags.
-  useIsomorphicLayoutEffect(() => {
-    setMounted(true);
-    positionPill(activeIndex);
-  }, [activeIndex, positionPill]);
-
   return (
-    <div
-      className="relative flex items-center rounded-full border border-accent-green-foreground/40"
-      ref={containerRef}
-    >
+    <div className="relative flex items-center rounded-full border border-accent-green-foreground/40">
       <span
         aria-hidden="true"
         className={cn(
-          "-translate-y-1/2 absolute top-1/2 h-8 rounded-full bg-accent-green-foreground",
-          // `left`/`right` rather than a transform: the pill resizes to each
-          // segment's width, and only the inset pair carries both at once.
-          // Skipped on the mount frame, or it flies in from the left edge.
-          mounted
-            ? "opacity-100 transition-[left,right] duration-300 ease-[var(--ease-spring)] motion-reduce:transition-none"
-            : "opacity-0"
+          "-translate-y-1/2 absolute top-1/2 left-0 h-8 w-1/3 rounded-full bg-accent-green-foreground",
+          // `!` beats the transition kill from `disableTransitionOnChange`.
+          "motion-safe:transition-transform! motion-safe:duration-300! motion-safe:ease-[var(--ease-spring)]!",
+          // hidden until mounted so the pill doesn't fly in from the left.
+          mounted ? PILL_OFFSETS[activeIndex] : "hidden"
         )}
-        ref={pillRef}
       />
-      {THEMES.map(({ value, label, Icon }, index) => {
+      {THEMES.map(({ value, label, Icon }) => {
         const active = mounted && theme === value;
         return (
           <button
@@ -82,9 +64,6 @@ export function FooterThemeToggle() {
             )}
             key={value}
             onClick={() => setTheme(value)}
-            ref={(el) => {
-              buttonRefs.current[index] = el;
-            }}
             type="button"
           >
             <Icon


### PR DESCRIPTION
## What changed

The sliding pill in `FooterThemeToggle` was positioned with three refs, an `offsetLeft`/`clientWidth` calculation against the container, and an isomorphic layout effect writing inline `left`/`right` styles. Despite all of that, the pill never actually slid — the animation was dead in the shipped version (see below).

The pill is now measured off the active button by a single callback ref — React runs it before paint whenever the active button changes — writing `left`/`width` directly:

- One function replaces the button ref array, the container math, and the layout effect.
- Measurement is kept deliberately: if a segment ever gains a text label, widths stop being equal and a fixed-width pill would break. Measuring the active button keeps positioning width-agnostic.
- The `mounted` state + effects were replaced with a one-line `useSyncExternalStore` hydration check (same idiom as `use-media-query.ts`); the pill stays `hidden` until placed, so it doesn't fly in from the left on mount.

## The bug that kept it from sliding

`disableTransitionOnChange` on the ThemeProvider injects `* { transition: none !important }` during every theme switch — which is the only moment the pill ever moves, so the transition was always suppressed, in the old implementation just the same. Fixed by marking the pill's transition utilities `!important` (class specificity beats the universal rule), gated behind `motion-safe:` so reduced-motion still wins.

Fixes ROB-2827



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme toggle positioning for more consistent alignment across screen sizes.
  * Prevented the sliding indicator from appearing in an incorrect position during initial page load by hiding it until the interface is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->