### PR TITLE
fix: let the GitHub stars link follow the navbar adaptive contrast

### DIFF
--- a/apps/web/src/components/github-stars.tsx
+++ b/apps/web/src/components/github-stars.tsx
@@ -28,7 +28,7 @@ export function GithubStars({
     <a
       aria-label={`GitHub repository, ${formatStars(stars)} stars (opens in a new tab)`}
       className={cn(
-        "focus-ring inline-flex h-8 items-center gap-2 rounded-full px-2 font-mono font-normal text-foreground text-sm uppercase tracking-wide",
+        "focus-ring inline-flex h-8 items-center gap-2 rounded-full px-2 font-mono font-normal text-foreground text-sm uppercase tracking-wide group-data-[nav-on=dark]:text-white group-data-[nav-on=light]:text-zinc-900",
         className
       )}
       href={gitHubUrl}


### PR DESCRIPTION
## Bug

When the navbar sits over a section marked `data-nav-contrast="dark"` (the showcase grid), the contrast logic stamps `data-nav-on="dark"` on every `data-nav-adaptive` element and the bar's content inverts to white — nav links via `NAV_LINK_CLASS`, the SIGN IN outline via `NAV_OUTLINE_ADAPTIVE`.

The GitHub stars link never opted in: its anchor is plain `text-foreground` with no `group-data-[nav-on=…]` variants, so the icon and count stay near-black over the dark image while everything around them turns white.

## Fix

One line — give the anchor the same ink pair the SIGN IN button uses, keyed off the same group stamp:

```
group-data-[nav-on=dark]:text-white group-data-[nav-on=light]:text-zinc-900
```

The icon follows automatically via `currentColor`. No border rule needed (the link has none), and the variants never match in the mobile row since that wrapper carries no `group`/`data-nav-adaptive`.

Verified on `/showcase`: over the dark section both the GitHub link and SIGN IN compute to `rgb(255,255,255)`; back at the top both return to theme ink together.

Before
<img width="1919" height="158" alt="Screenshot 2026-09-01 120922" src="https://github.com/user-attachments/assets/5c7bc317-7623-4b8e-9957-6bdaad1556ea" />


After
<img width="1917" height="167" alt="Screenshot 2026-09-01 121326" src="https://github.com/user-attachments/assets/ad959bbe-bf33-4e37-a3cf-2dfd26c7a602" />


Fixes ROB-2829
