### PR TITLE
feat: animate copy button status changes

### DIFF
--- a/apps/web/src/components/copy-markdown-button.tsx
+++ b/apps/web/src/components/copy-markdown-button.tsx
@@ -74,7 +74,9 @@ export function CopyMarkdownButton({
                 SWAP_LAYER,
                 "size-4.5",
                 active ? SWAP_SHOWN : SWAP_HIDDEN,
-                active && s === "loading" && "animate-spin"
+                active &&
+                  s === "loading" &&
+                  "animate-spin motion-reduce:animate-none"
               )}
               key={s}
             />

--- a/apps/web/src/components/copy-markdown-button.tsx
+++ b/apps/web/src/components/copy-markdown-button.tsx
@@ -4,6 +4,11 @@ import { CopyIcon } from "@workspace/sanity-blocks/internal/icons";
 import {
   COPY_STATUS_CLASS,
   type CopyStatus,
+  SWAP_HIDDEN,
+  SWAP_LAYER,
+  SWAP_SHOWN,
+  SWAP_TEXT_HIDDEN,
+  SWAP_TEXT_SHOWN,
   useCopyToClipboard,
 } from "@workspace/sanity-blocks/internal/use-copy";
 import { cn } from "@workspace/tailwind-config/utils";
@@ -23,7 +28,9 @@ const STATUS_ICONS = {
   loading: Loader2,
   copied: Check,
   error: X,
-};
+} as const;
+
+const STATUSES = Object.keys(STATUS_ICONS) as CopyStatus[];
 
 /** Every page is also served as Markdown at its `.md` path. */
 function markdownPath(pathname: string): string {
@@ -43,8 +50,6 @@ export function CopyMarkdownButton({
   }, [pathname]);
   const { status, copy } = useCopyToClipboard(getMarkdown);
 
-  const StatusIcon = STATUS_ICONS[status];
-
   return (
     <button
       aria-label={LABELS.idle}
@@ -60,20 +65,41 @@ export function CopyMarkdownButton({
         aria-hidden="true"
         className="grid size-4.5 flex-none place-items-center"
       >
-        <StatusIcon
-          className={cn("size-4.5", status === "loading" && "animate-spin")}
-        />
+        {STATUSES.map((s) => {
+          const Icon = STATUS_ICONS[s];
+          const active = s === status;
+          return (
+            <Icon
+              className={cn(
+                SWAP_LAYER,
+                "size-4.5",
+                active ? SWAP_SHOWN : SWAP_HIDDEN,
+                active && s === "loading" && "animate-spin"
+              )}
+              key={s}
+            />
+          );
+        })}
       </span>
       <span className="grid text-left">
         <span aria-hidden="true" className="col-start-1 row-start-1 invisible">
           {LABELS.idle}
         </span>
-        {/* The label is the only thing that reports the outcome, and it swaps
-            in place. As a live region the change is spoken; without it a
-            screen-reader user gets no confirmation the copy landed. */}
-        <output className="col-start-1 row-start-1 truncate">
-          {LABELS[status]}
-        </output>
+        {STATUSES.map((s) => (
+          <span
+            aria-hidden="true"
+            className={cn(
+              SWAP_LAYER,
+              "truncate",
+              s === status ? SWAP_TEXT_SHOWN : SWAP_TEXT_HIDDEN
+            )}
+            key={s}
+          >
+            {LABELS[s]}
+          </span>
+        ))}
+        {/* Live region: the spoken confirmation that the copy landed. */}
+        <output className="sr-only">{LABELS[status]}</output>
       </span>
     </button>
   );

--- a/apps/web/src/components/elements/table-of-content.tsx
+++ b/apps/web/src/components/elements/table-of-content.tsx
@@ -13,6 +13,11 @@ import {
 } from "@workspace/sanity-blocks/internal/icons";
 import {
   COPY_STATUS_CLASS,
+  SWAP_HIDDEN,
+  SWAP_LAYER,
+  SWAP_SHOWN,
+  SWAP_TEXT_HIDDEN,
+  SWAP_TEXT_SHOWN,
   useCopyToClipboard,
 } from "@workspace/sanity-blocks/internal/use-copy";
 import {
@@ -645,26 +650,35 @@ function ShareOptions({
         onClick={copy}
         type="button"
       >
-        <span className="grid size-4.5 place-items-center">
-          {copied ? (
-            <Check aria-hidden="true" className="size-4.5" />
-          ) : (
-            <CopyIcon className="size-4.5" />
-          )}
+        <span aria-hidden="true" className="grid size-4.5 place-items-center">
+          <Check
+            className={cn(
+              SWAP_LAYER,
+              "size-4.5",
+              copied ? SWAP_SHOWN : SWAP_HIDDEN
+            )}
+          />
+          <CopyIcon
+            className={cn(
+              SWAP_LAYER,
+              "size-4.5",
+              copied ? SWAP_HIDDEN : SWAP_SHOWN
+            )}
+          />
         </span>
-        <span className="grid text-xs tracking-[0.02em]">
+        <span aria-hidden="true" className="grid text-xs tracking-[0.02em]">
           <span
             className={cn(
-              "col-start-1 row-start-1",
-              copied ? "visible" : "invisible"
+              SWAP_LAYER,
+              copied ? SWAP_TEXT_SHOWN : SWAP_TEXT_HIDDEN
             )}
           >
             Copied
           </span>
           <span
             className={cn(
-              "col-start-1 row-start-1",
-              copied ? "invisible" : "visible"
+              SWAP_LAYER,
+              copied ? SWAP_TEXT_HIDDEN : SWAP_TEXT_SHOWN
             )}
           >
             Copy

--- a/packages/sanity-blocks/src/internal/copy-button.tsx
+++ b/packages/sanity-blocks/src/internal/copy-button.tsx
@@ -4,7 +4,13 @@ import { cn } from "@workspace/tailwind-config/utils";
 import { Check } from "lucide-react";
 
 import { CopyIcon } from "./icons";
-import { COPY_STATUS_CLASS, useCopyToClipboard } from "./use-copy";
+import {
+  COPY_STATUS_CLASS,
+  SWAP_HIDDEN,
+  SWAP_LAYER,
+  SWAP_SHOWN,
+  useCopyToClipboard,
+} from "./use-copy";
 
 export function CopyButton({ code }: Readonly<{ code: string }>) {
   const { status, copy } = useCopyToClipboard(() => code);
@@ -23,12 +29,21 @@ export function CopyButton({ code }: Readonly<{ code: string }>) {
       onClick={copy}
       type="button"
     >
-      <span className="grid size-4 place-items-center">
-        {copied ? (
-          <Check aria-hidden="true" className="size-4" />
-        ) : (
-          <CopyIcon className="size-4" />
-        )}
+      <span aria-hidden="true" className="grid size-4 place-items-center">
+        <Check
+          className={cn(
+            SWAP_LAYER,
+            "size-4",
+            copied ? SWAP_SHOWN : SWAP_HIDDEN
+          )}
+        />
+        <CopyIcon
+          className={cn(
+            SWAP_LAYER,
+            "size-4",
+            copied ? SWAP_HIDDEN : SWAP_SHOWN
+          )}
+        />
       </span>
       <output className="sr-only">{copied ? "Copied to clipboard" : ""}</output>
     </button>

--- a/packages/sanity-blocks/src/internal/use-copy.ts
+++ b/packages/sanity-blocks/src/internal/use-copy.ts
@@ -20,6 +20,15 @@ export const COPY_STATUS_CLASS: Record<CopyStatus, string> = {
   error: "text-danger hover:text-danger",
 };
 
+// Grid-stacked status swap shared by the copy buttons: the active layer
+// scales/blurs in over the rest. Text layers fade/blur only — no scale.
+export const SWAP_LAYER =
+  "col-start-1 row-start-1 transition-[opacity,filter,scale] duration-300 ease-in-out motion-reduce:transition-none";
+export const SWAP_SHOWN = "scale-100 opacity-100 blur-0";
+export const SWAP_HIDDEN = "scale-[0.25] opacity-0 blur-xs";
+export const SWAP_TEXT_SHOWN = "opacity-100 blur-0";
+export const SWAP_TEXT_HIDDEN = "opacity-0 blur-xs";
+
 export function useCopyToClipboard(
   getText: () => string | Promise<string>,
   resetMs: number = COPY_RESET_MS


### PR DESCRIPTION
All copy buttons (copy-as-markdown, code block, share link) swapped their icons instantly. This adds a shared blur/scale crossfade between status icons, with labels fading in sync (no scale on text). Shared `SWAP_*` classes live in `use-copy.ts` so the three buttons can't drift apart. Honors reduced motion.

Fixes ROB-2834


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved copy-button feedback with smoother animated transitions between copy, loading, and completed states.
  * Updated copy-link controls with layered icon and label transitions.
  * Preserved accessible status announcements while keeping visual transitions clear.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->