### PR TITLE
fix: align feature card headings and hero headline wrapping

### DIFF
--- a/packages/sanity-blocks/src/feature-cards-icon/index.tsx
+++ b/packages/sanity-blocks/src/feature-cards-icon/index.tsx
@@ -20,9 +20,9 @@ export interface FeatureCardsIconProps {
 function FeatureCardItem({ card }: Readonly<{ card: FeatureCard }>) {
   const { icon, title, richText } = card;
   return (
-    <div className="group flex min-w-0 transform-gpu flex-col justify-between gap-12 bg-background p-[31.2px] text-foreground transition-colors duration-200 ease-out hover:bg-accent-green hover:text-accent-green-foreground md:min-h-72 md:gap-16">
+    <div className="group flex min-w-0 transform-gpu flex-col gap-12 bg-background p-[31.2px] text-foreground transition-colors duration-200 ease-out hover:bg-accent-green hover:text-accent-green-foreground lg:row-span-3 lg:grid lg:min-h-72 lg:grid-rows-subgrid lg:gap-0">
       {icon && (
-        <div className="-mr-[31.2px] relative flex h-12 items-center">
+        <div className="-mr-[31.2px] relative flex h-12 items-center lg:row-start-1 lg:mb-12">
           <span
             aria-hidden="true"
             className="absolute inset-y-0 right-0 left-12 bg-grid-dots bg-left text-accent-green-foreground opacity-0 transition-opacity duration-200 ease-out group-hover:opacity-100"
@@ -34,14 +34,15 @@ function FeatureCardItem({ card }: Readonly<{ card: FeatureCard }>) {
           </div>
         </div>
       )}
-      <div className="flex min-w-0 flex-col gap-2">
+      {/* Dissolved on lg so heading and body land in the shared subgrid rows. */}
+      <div className="flex min-w-0 flex-col gap-2 lg:contents">
         {title ? (
-          <h3 className="text-balance break-words font-medium text-xl leading-8">
+          <h3 className="text-balance break-words font-medium text-xl leading-8 lg:row-start-2 lg:mb-2 lg:min-w-0">
             {title}
           </h3>
         ) : null}
         <RichText
-          className="body-text break-words text-muted-foreground transition-colors duration-200 ease-out group-hover:text-accent-green-foreground/80"
+          className="body-text break-words text-muted-foreground transition-colors duration-200 ease-out group-hover:text-accent-green-foreground/80 lg:row-start-3 lg:min-w-0"
           richText={richText}
         />
       </div>

--- a/packages/sanity-blocks/src/hero/index.tsx
+++ b/packages/sanity-blocks/src/hero/index.tsx
@@ -192,7 +192,7 @@ export function HeroBlock({
     <div className="container grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end lg:gap-12">
       <div className="grid gap-5">
         <BlockEyebrow eyebrow={badge} />
-        <h1 className="hero-enter max-w-[827px] break-words font-normal text-4xl text-foreground leading-[1.1] tracking-[-0.24px] sm:text-5xl lg:text-[64px]">
+        <h1 className="hero-enter max-w-[827px] text-pretty break-words font-normal text-4xl text-foreground leading-[1.1] tracking-[-0.24px] sm:text-5xl lg:text-[64px]">
           {title}
         </h1>
         <RichText


### PR DESCRIPTION
Feature card headings sat at different heights because `justify-between` bottom-anchored each card's text. This replaces that with subgrid rows at `lg` so icon/heading/body align across cards, sets the icon→text gap to 48px at every breakpoint, and scopes `min-h-72` to `lg` so stacked cards no longer carry dead space.

Also adds `text-pretty` to the hero h1 to stop a lone word wrapping to its own line. `balance` was tried first but produces a short-over-long split on copy this short.

Before
<img width="1398" height="432" alt="Screenshot 2026-09-01 130340" src="https://github.com/user-attachments/assets/1abe3dd5-f29d-412b-bf08-0a9cff392a54" />

After
<img width="1543" height="512" alt="Screenshot 2026-09-01 140440" src="https://github.com/user-attachments/assets/01626a5d-8713-49a5-9e11-2b3d74b5896d" />


Fixes ROB-2835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved feature card layouts at larger screen sizes for more consistent alignment of icons, titles, and descriptions.
  * Enhanced hero title text wrapping for improved readability across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->