### PR TITLE
fix: make the mobile menu full height

### DIFF
--- a/apps/web/src/components/mobile-menu.tsx
+++ b/apps/web/src/components/mobile-menu.tsx
@@ -39,7 +39,7 @@ const VIEWPORT_ANCHOR = {
 
 const POPUP_SLIDE = {
   bottom:
-    "h-[90dvh] border-t origin-bottom [transform:translateY(var(--drawer-swipe-movement-y,0px))] data-starting-style:[transform:translateY(100%)] data-ending-style:[transform:translateY(100%)]",
+    "h-dvh origin-bottom [transform:translateY(var(--drawer-swipe-movement-y,0px))] data-starting-style:[transform:translateY(100%)] data-ending-style:[transform:translateY(100%)]",
   right:
     "h-dvh max-w-md border-s origin-right [transform:translateX(var(--drawer-swipe-movement-x,0px))] data-starting-style:[transform:translateX(100%)] data-ending-style:[transform:translateX(100%)]",
 } as const;


### PR DESCRIPTION
The phone bottom sheet was `h-[90dvh]`, leaving the dimmed navbar peeking above it — redundant since the sheet has its own logo header, so the peek showed two logos stacked. Now `h-dvh` (matching the tablet drawer) with the top border dropped.

Before
<img width="848" height="1840" alt="iPhone-14-PRO-localhost" src="https://github.com/user-attachments/assets/94c86f09-604d-4a90-9a91-54a346b4eab4" />

After
<img width="848" height="1840" alt="iPhone-14-PRO-localhost (1)" src="https://github.com/user-attachments/assets/29f9f823-c1b9-465d-aec5-465896f5c5ae" />

Fixes ROB-2836
