### PR TITLE
fix: close the nav drawer when the viewport crosses its breakpoint

### DIFF
--- a/apps/web/src/components/mobile-menu.tsx
+++ b/apps/web/src/components/mobile-menu.tsx
@@ -64,6 +64,11 @@ export function MobileMenu({
     setIsOpen(false);
   }
 
+  // On desktop the trigger is display:none, so focus would drop to body.
+  const finalFocus = isDesktop
+    ? () => document.querySelector<HTMLElement>("header a[href]")
+    : undefined;
+
   function handleOpenChange(next: boolean) {
     if (next) {
       setSide(liveSide);
@@ -86,7 +91,7 @@ export function MobileMenu({
   return (
     <Drawer
       onOpenChange={handleOpenChange}
-      open={isOpen && !isDesktop}
+      open={isOpen}
       swipeDirection={side === "right" ? "right" : "down"}
     >
       <DrawerTrigger
@@ -110,6 +115,7 @@ export function MobileMenu({
               "w-full pb-[env(safe-area-inset-bottom)]",
               POPUP_SLIDE[side]
             )}
+            finalFocus={finalFocus}
           >
             <DrawerContent>
               <div className="flex flex-row items-center justify-between border-b px-6 py-2.5">

--- a/apps/web/src/components/mobile-menu.tsx
+++ b/apps/web/src/components/mobile-menu.tsx
@@ -30,7 +30,8 @@ import { MenuLink } from "@/components/elements/menu-link";
 import { Logo } from "@/components/logo";
 import type { ColumnLink, NavigationData } from "@/types";
 
-const TABLET_QUERY = "(min-width: 768px) and (max-width: 1024px)";
+const TABLET_QUERY = "(min-width: 768px) and (max-width: 1023.98px)";
+const DESKTOP_QUERY = "(min-width: 1024px)";
 
 const VIEWPORT_ANCHOR = {
   bottom: "items-end justify-center",
@@ -51,11 +52,17 @@ export function MobileMenu({
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
   const isTablet = useMediaQuery(TABLET_QUERY);
+  const isDesktop = useMediaQuery(DESKTOP_QUERY);
   const liveSide = isTablet ? "right" : "bottom";
+
   // Freeze the anchor at open-time and keep it for the whole session, so crossing
   // the breakpoint (e.g. a tablet rotation) or closing never re-anchors a visible
   // panel — re-anchoring on close would jump the sheet mid-exit-animation.
   const [side, setSide] = useState<"bottom" | "right">(liveSide);
+
+  if (isOpen && (isDesktop || side !== liveSide)) {
+    setIsOpen(false);
+  }
 
   function handleOpenChange(next: boolean) {
     if (next) {
@@ -79,7 +86,7 @@ export function MobileMenu({
   return (
     <Drawer
       onOpenChange={handleOpenChange}
-      open={isOpen}
+      open={isOpen && !isDesktop}
       swipeDirection={side === "right" ? "right" : "down"}
     >
       <DrawerTrigger


### PR DESCRIPTION
## Bug

The menu's variant is chosen when it opens — bottom sheet on phones, right-side drawer on tablets — and never re-checked, and nothing closed an open menu when the viewport changed. Resizing across a breakpoint therefore left the wrong variant on screen: a full-width bottom sheet covering a desktop page (where the hamburger doesn't even exist), a bottom sheet at tablet, or the right drawer on a phone.

## Fix

One mechanism: during render, if the drawer is open at a width it doesn't belong to, its state resets and it closes.

```tsx
if (isOpen && (isDesktop || side !== liveSide)) {
  setIsOpen(false);
}
```

- `isDesktop` — the viewport crossed into `lg`, where the trigger is hidden
- `side !== liveSide` — the frozen anchor no longer matches the variant this width uses (mobile ↔ tablet crossing)

Two supporting changes:

- Media queries now match Tailwind's `md`/`lg` exactly (the old tablet query overlapped desktop at exactly 1024px)
- When the desktop crossing closes the drawer, `finalFocus` moves keyboard focus to the header logo link — the hamburger it would normally return to is `display:none`. Normal closes keep the default return-to-trigger, since the prop is only passed on desktop

Verified opening and resizing in every direction (no wrong variant survives, no phantom reopen), plus focus restore on Escape and on the resize close.

Fixes ROB-2837


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive navigation behavior across tablet and desktop screen sizes.
  * The mobile menu now stays closed on desktop displays.
  * Automatically closes the menu when the layout or menu position changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->