### PR TITLE
fix: treat empty env strings as unset so optional vars accept blanks (#454)

### DIFF
--- a/packages/env/src/client.ts
+++ b/packages/env/src/client.ts
@@ -37,17 +37,11 @@ const env = createEnv({
 
     /** Canonical public origin. Required off Vercel — without it every
      *  canonical, OG url, sitemap entry and JSON-LD @id is localhost. */
-    NEXT_PUBLIC_SITE_URL: z.preprocess(
-      (value) => (value === "" ? undefined : value),
-      z.url().optional()
-    ),
+    NEXT_PUBLIC_SITE_URL: z.url().optional(),
 
     NEXT_PUBLIC_SANITY_PROJECT_ID: z.string().min(1),
     NEXT_PUBLIC_SANITY_DATASET: z.string().min(1),
-    NEXT_PUBLIC_SANITY_API_VERSION: z.preprocess(
-      (value) => (value === "" ? undefined : value),
-      z.string().min(1).optional()
-    ),
+    NEXT_PUBLIC_SANITY_API_VERSION: z.string().min(1).optional(),
     NEXT_PUBLIC_SANITY_STUDIO_URL: z.url().min(1),
   },
 
@@ -65,6 +59,9 @@ const env = createEnv({
     NEXT_PUBLIC_SANITY_PROJECT_ID: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
     NEXT_PUBLIC_SANITY_DATASET: process.env.NEXT_PUBLIC_SANITY_DATASET,
   },
+
+  // Treat empty env strings as unset so `.optional()` vars accept a blank value.
+  emptyStringAsUndefined: true,
 });
 
 export { env };

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -21,6 +21,10 @@ const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
   },
 
+  // Treat empty env strings (e.g. `SANITY_REVALIDATE_SECRET=` in .env.example)
+  // as unset, so `.optional()` vars don't fail `.min(1)` on a blank value.
+  emptyStringAsUndefined: true,
+
   extends: [vercel()],
 });
 


### PR DESCRIPTION
## Problem

`pnpm dev` and `pnpm build` crash with `Invalid environment variables` when `SANITY_REVALIDATE_SECRET` is unset, even though it's documented as optional (the `/api/revalidate-sync-tags` webhook is meant to just fail closed when it's absent). `apps/web/.env.example` ships `SANITY_REVALIDATE_SECRET=` — an empty string, not an absent var — so `process.env.SANITY_REVALIDATE_SECRET` resolves to `""`. The schema `z.string().min(1).optional()` only tolerates `undefined`; `""` still fails `.min(1)`, so Zod throws. Because `apps/web/next.config.ts` imports `@workspace/env/server` at load time, this takes down the whole dev/build process instead of quietly disabling the webhook. Fixes #454.

## Approach

Add `emptyStringAsUndefined: true` to the `createEnv` call in both `packages/env/src/server.ts` and `packages/env/src/client.ts`. `@t3-oss/env-nextjs` defaults this to `false`; turning it on coerces every empty env string to `undefined` before validation, so `.optional()` vars accept a blank value while genuinely-required vars (no `.optional()`) still fail loudly. In `client.ts` this made the two per-field `z.preprocess((value) => (value === "" ? undefined : value), ...)` wrappers on `NEXT_PUBLIC_SITE_URL` and `NEXT_PUBLIC_SANITY_API_VERSION` redundant — the global flag does the same `"" → undefined` coercion — so they're removed in favor of plain `.optional()`.

## Verification

- [x] `pnpm --filter @workspace/env check-types`
- [x] Env module boots with `SANITY_REVALIDATE_SECRET=` empty (verified importing `@workspace/env/server` under `tsx`)
- [x] A genuinely-required blank var (e.g. `SANITY_API_READ_TOKEN=`) still fails validation
- [x] `pnpm dev:web` boots end-to-end with `SANITY_REVALIDATE_SECRET=` empty (`✓ Ready in 1776ms`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty optional environment variables are now treated as unset instead of triggering validation errors.
  * Blank configuration values no longer fail minimum-length checks during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->