### PR TITLE
feat: replace the unmaintained Lucide icon picker, unpin @sanity/ui 3

### DIFF
--- a/apps/studio/components/slug-field-component.tsx
+++ b/apps/studio/components/slug-field-component.tsx
@@ -1,4 +1,4 @@
-import { CopyIcon } from "@sanity/icons";
+import { CopyIcon } from "@sanity/icons/Copy";
 import { Box, Button, Card, Flex, Stack, Text, TextInput } from "@sanity/ui";
 import type { ChangeEvent } from "react";
 import { useCallback, useMemo } from "react";
@@ -123,9 +123,9 @@ export function PathnameFieldComponent(props: ObjectFieldProps<SlugValue>) {
     !(typeof document?.title === "string" && document.title.trim()) || readOnly;
 
   return (
-    <Stack space={4}>
+    <Stack gap={4}>
       {(title || description) && (
-        <Stack space={2}>
+        <Stack gap={2}>
           {title && (
             <Text size={1} weight="semibold">
               {title}
@@ -139,8 +139,8 @@ export function PathnameFieldComponent(props: ObjectFieldProps<SlugValue>) {
         </Stack>
       )}
 
-      <Stack space={4}>
-        <Stack space={2}>
+      <Stack gap={4}>
+        <Stack gap={2}>
           <Text size={1} weight="medium">
             URL Path
           </Text>
@@ -175,7 +175,7 @@ export function PathnameFieldComponent(props: ObjectFieldProps<SlugValue>) {
         </Text>
 
         {currentSlug && errors.length === 0 && (
-          <Stack space={2}>
+          <Stack gap={2}>
             <Text size={1} weight="medium">
               Preview
             </Text>

--- a/apps/studio/components/url-slug/validation-messages.tsx
+++ b/apps/studio/components/url-slug/validation-messages.tsx
@@ -24,7 +24,7 @@ export function ValidationMessages({
   }
 
   return (
-    <Stack space={2}>
+    <Stack gap={2}>
       {uniqueErrors.map((error) => (
         <Card key={error} padding={3} radius={2} tone="critical">
           <Text size={1} style={errorTextStyle}>

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -23,6 +23,7 @@
     "sanity"
   ],
   "dependencies": {
+    "@robotostudio/sanity-plugin-lucide-icon-picker": "^1.0.0",
     "@sanity/assist": "^6.1.21",
     "@sanity/client": "catalog:",
     "@sanity/functions": "^1.6.9",
@@ -41,7 +42,6 @@
     "react-is": "catalog:",
     "sanity": "catalog:",
     "sanity-plugin-asset-source-unsplash": "^7.0.25",
-    "sanity-plugin-lucide-icon-picker": "^1.0.3",
     "sanity-plugin-media": "^6.1.6",
     "sanity-plugin-mux-input": "^5.0.12",
     "slugify": "^1.6.9",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -23,13 +23,13 @@
     "sanity"
   ],
   "dependencies": {
-    "@robotostudio/sanity-plugin-lucide-icon-picker": "^1.0.0",
+    "@robotostudio/sanity-plugin-lucide-icon-picker": "^1.0.2",
     "@sanity/assist": "^6.1.21",
     "@sanity/client": "catalog:",
     "@sanity/functions": "^1.6.9",
-    "@sanity/icons": "^3.8.0",
+    "@sanity/icons": "^5.2.1",
     "@sanity/orderable-document-list": "^2.0.22",
-    "@sanity/ui": "^3.5.3",
+    "@sanity/ui": "^4.0.6",
     "@sanity/vision": "^6.11.0",
     "@workspace/env": "workspace:*",
     "@workspace/logger": "workspace:*",

--- a/apps/studio/plugins/presentation-url.ts
+++ b/apps/studio/plugins/presentation-url.ts
@@ -1,6 +1,6 @@
 import type { SanityDocument } from "@sanity/client";
-import { EarthGlobeIcon } from "@sanity/icons";
-import { useToast } from "@sanity/ui";
+import { EarthGlobeIcon } from "@sanity/icons/EarthGlobe";
+import { useToast } from "@sanity/ui/toast";
 import { useCallback } from "react";
 import {
   type DocumentActionComponent,

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -1,10 +1,10 @@
+import { lucideIconPicker } from "@robotostudio/sanity-plugin-lucide-icon-picker";
 import { assist } from "@sanity/assist";
 import { visionTool } from "@sanity/vision";
 import { defineConfig } from "sanity";
 import { presentationTool } from "sanity/presentation";
 import { structureTool } from "sanity/structure";
 import { unsplashImageAsset } from "sanity-plugin-asset-source-unsplash";
-import { lucideIconPicker } from "sanity-plugin-lucide-icon-picker";
 import { media } from "sanity-plugin-media";
 import { muxInput } from "sanity-plugin-mux-input";
 

--- a/apps/studio/utils/constant.ts
+++ b/apps/studio/utils/constant.ts
@@ -1,4 +1,6 @@
-import { ComposeIcon, InsertAboveIcon, SearchIcon } from "@sanity/icons";
+import { ComposeIcon } from "@sanity/icons/Compose";
+import { InsertAboveIcon } from "@sanity/icons/InsertAbove";
+import { SearchIcon } from "@sanity/icons/Search";
 import { DEFAULT_SANITY_API_VERSION } from "@workspace/env/constants";
 import type { FieldGroupDefinition } from "sanity";
 

--- a/packages/sanity-blocks/package.json
+++ b/packages/sanity-blocks/package.json
@@ -23,7 +23,7 @@
     "@mux/mux-video-react": "^0.31.2",
     "@portabletext/markdown": "^2.0.0",
     "@sanity/client": "catalog:",
-    "@sanity/icons": "^3.8.0",
+    "@sanity/icons": "^5.2.1",
     "@workspace/env": "workspace:*",
     "@workspace/logger": "workspace:*",
     "@workspace/tailwind-config": "workspace:*",

--- a/packages/sanity-blocks/src/internal/sanity-rich-text.ts
+++ b/packages/sanity-blocks/src/internal/sanity-rich-text.ts
@@ -1,4 +1,7 @@
-import { CodeBlockIcon, ImageIcon, LinkIcon, ThLargeIcon } from "@sanity/icons";
+import { CodeBlockIcon } from "@sanity/icons/CodeBlock";
+import { ImageIcon } from "@sanity/icons/Image";
+import { LinkIcon } from "@sanity/icons/Link";
+import { ThLargeIcon } from "@sanity/icons/ThLarge";
 import {
   type ConditionalProperty,
   defineArrayMember,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
   apps/studio:
     dependencies:
       '@robotostudio/sanity-plugin-lucide-icon-picker':
-        specifier: ^1.0.0
-        version: 1.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        specifier: ^1.0.2
+        version: 1.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@sanity/assist':
         specifier: ^6.1.21
         version: 6.1.21(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11(@types/node@26.3.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.37.0)(tsx@4.23.12)(yaml@2.9.0)))
@@ -108,14 +108,14 @@ importers:
         specifier: ^1.6.9
         version: 1.6.9(@aws-lite/client@0.23.7)(@aws-lite/dynamodb@0.3.9)(@aws-lite/lambda@0.1.5)(@aws-lite/sns@0.0.8)(@aws-lite/sqs@0.2.4)
       '@sanity/icons':
-        specifier: ^3.8.0
-        version: 3.8.0(react@19.2.8)
+        specifier: ^5.2.1
+        version: 5.2.1(react@19.2.8)
       '@sanity/orderable-document-list':
         specifier: ^2.0.22
         version: 2.0.22(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(vitest@4.1.11(@types/node@26.3.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.37.0)(tsx@4.23.12)(yaml@2.9.0)))
       '@sanity/ui':
-        specifier: ^3.5.3
-        version: 3.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        specifier: ^4.0.6
+        version: 4.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@sanity/vision':
         specifier: ^6.11.0
         version: 6.11.0(@babel/runtime@7.29.7)(@codemirror/lint@6.8.5)(@codemirror/theme-one-dark@6.1.2)(codemirror@6.0.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(vitest@4.1.11(@types/node@26.3.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.37.0)(tsx@4.23.12)(yaml@2.9.0)))
@@ -343,8 +343,8 @@ importers:
         specifier: 'catalog:'
         version: 7.26.2
       '@sanity/icons':
-        specifier: ^3.8.0
-        version: 3.8.0(react@19.2.8)
+        specifier: ^5.2.1
+        version: 5.2.1(react@19.2.8)
       '@workspace/env':
         specifier: workspace:*
         version: link:../env
@@ -2035,9 +2035,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@juggle/resize-observer@3.4.0':
-    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
-
   '@lezer/common@1.5.1':
     resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
 
@@ -2446,8 +2443,8 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.0':
-    resolution: {integrity: sha512-OlESlOI1z/btli0zx3j7lKkXc5XHZmVZi8/8k5pYzWUbxeDwv9f58diFMCC6sSX2lnKCIIOmSXTBTaLDX1SPVw==}
+  '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.2':
+    resolution: {integrity: sha512-5VR6K/3BDWq9wD/KcRH6it+Jmj2ChUmc2OCdUyvpF1ub1iZ8SyhCLrOkShOEwd1e/nTINOuAz/HY58kvPYE2Ig==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^19.2
@@ -2758,12 +2755,6 @@ packages:
   '@sanity/generate-help-url@4.0.0':
     resolution: {integrity: sha512-Ooa4xkLT3TLaX+mw/13fq3IeGdnAkx4rbpVASvRVixzBBvvcL6jPqj50fjlCd+EhgB5GRXBCNNAy/hWXwjZEUA==}
 
-  '@sanity/icons@3.8.0':
-    resolution: {integrity: sha512-LXa8eoE6U2e46L/9Pk6VU1aOWNxEqEG1osTb2YWItPIAa8MyXkICRwdNRWwW3kr5gmf+Sh2ZmfKol/Q+oGKSqw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: ^18.3 || ^19.0.0-0
-
   '@sanity/icons@5.2.1':
     resolution: {integrity: sha512-P5gY1HRungh4RgCcypdIpu/SKoTwRBTttpbHntZjdW1MO3MK6xEOs+pbAzSARyhh22OcN9PkBBEYk2FL34BvfQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -2907,14 +2898,6 @@ packages:
     engines: {node: '>=22.12'}
     peerDependencies:
       '@types/react': '*'
-
-  '@sanity/ui@3.5.3':
-    resolution: {integrity: sha512-CedYCI42/qWp2IbYaFR/kCo+u2EjgWl0vd0FFTwiTvqpYzXeC2B9NQH/jmD77r3jGBwS0chtvUQeLxVZdezkUQ==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-    peerDependencies:
-      react: ^18 || >=19.0.0-0
-      react-dom: ^18 || >=19.0.0-0
-      styled-components: ^5.2 || ^6
 
   '@sanity/ui@4.0.6':
     resolution: {integrity: sha512-iPtHRtnwcwq2ePHVrXsmTCFLNkEYfXL0kSavY4gnfkrbCPOmMD4iMe5MKcRtQ2YrJug6K70c6JQRCB+gN8kNaA==}
@@ -8210,8 +8193,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@juggle/resize-observer@3.4.0': {}
-
   '@lezer/common@1.5.1': {}
 
   '@lezer/highlight@1.2.3':
@@ -8673,7 +8654,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/ui': 4.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
@@ -9499,10 +9480,6 @@ snapshots:
 
   '@sanity/generate-help-url@4.0.0': {}
 
-  '@sanity/icons@3.8.0(react@19.2.8)':
-    dependencies:
-      react: 19.2.8
-
   '@sanity/icons@5.2.1(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -10007,22 +9984,6 @@ snapshots:
       '@types/react': 19.2.18
     transitivePeerDependencies:
       - vitest
-
-  '@sanity/ui@3.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.8
-      '@sanity/icons': 5.2.1(react@19.2.8)
-      csstype: 3.2.3
-      motion: 13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-compiler-runtime: 1.0.0(react@19.2.8)
-      react-dom: 19.2.8(react@19.2.8)
-      react-is: 19.2.8
-      react-refractor: 4.0.0(react@19.2.8)
-      styled-components: 6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      use-effect-event: 2.0.3(react@19.2.8)
 
   '@sanity/ui@4.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
 
   apps/studio:
     dependencies:
+      '@robotostudio/sanity-plugin-lucide-icon-picker':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@sanity/assist':
         specifier: ^6.1.21
         version: 6.1.21(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11(@types/node@26.3.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.37.0)(tsx@4.23.12)(yaml@2.9.0)))
@@ -149,9 +152,6 @@ importers:
       sanity-plugin-asset-source-unsplash:
         specifier: ^7.0.25
         version: 7.0.25(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      sanity-plugin-lucide-icon-picker:
-        specifier: ^1.0.3
-        version: 1.0.3(@sanity/icons@3.8.0(react@19.2.8))(@sanity/ui@3.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))
       sanity-plugin-media:
         specifier: ^6.1.6
         version: 6.1.6(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11(@types/node@26.3.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.37.0)(tsx@4.23.12)(yaml@2.9.0)))
@@ -2446,6 +2446,13 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.0':
+    resolution: {integrity: sha512-OlESlOI1z/btli0zx3j7lKkXc5XHZmVZi8/8k5pYzWUbxeDwv9f58diFMCC6sSX2lnKCIIOmSXTBTaLDX1SPVw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^19.2
+      sanity: ^6
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2917,8 +2924,8 @@ packages:
       react-dom: ^19.2
       styled-components: ^6.1
 
-  '@sanity/ui@5.0.0-alpha.7':
-    resolution: {integrity: sha512-hf/PNN9RSuRBaNUwGowj5yutd7OGTeDKaSd7uMFAeGZfz8lZ6DqtN2Aeqb4yeI+7QiezfelYP39gPLyrjVzLGg==}
+  '@sanity/ui@5.0.0-alpha.8':
+    resolution: {integrity: sha512-97d8U9/gXi7Y09NuOSYSmg7AZucxdLGY465F1c0iS4TlO5oN3qP7hzxYoxdRfYESCaY3I2nPIkFrGViLYKDfwQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
     peerDependencies:
@@ -4796,11 +4803,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.532.0:
-    resolution: {integrity: sha512-HwmXOIZwuZ21wryFq0ZrwkjAMxI77+jLxLdNzWCiUa/Kf5ozkTFCWT6C1/yapP68uKgj8wlxxqnNCH1xo9NEpg==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   lucide-react@1.34.0:
     resolution: {integrity: sha512-vnjGJNI7Htk5+oWW8gXGuaLgwgAb0T6/iZbBrp9JCfRFwdNWZ0YTm3eyxjOLgwN6r8iyAf3UA70zNmBRBNv7yg==}
     peerDependencies:
@@ -5536,15 +5538,6 @@ packages:
       react: ^19.2
       sanity: ^5 || ^6.0.0-0
       styled-components: ^6.1
-
-  sanity-plugin-lucide-icon-picker@1.0.3:
-    resolution: {integrity: sha512-3KS2pE4pCJ/LbUVw0iA2cCg/0KjMSnbEei9VJW3blAtwQRgionRgpytDcCJ1pXMho9gZc6Aqa91Jpjn3TllccA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@sanity/icons': ^3.7.0
-      '@sanity/ui': ^2.0.0
-      react: ^18 || ^19
-      sanity: ^3
 
   sanity-plugin-media@6.1.6:
     resolution: {integrity: sha512-cLTtYheW9VESqNxz1WYhNmiZtI1ceNn2yE9fdJhkuku2tUV0SK5/gIpGOhsMche4R6tfVdH9EnPk1RluNkf/IA==}
@@ -8680,6 +8673,17 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+    dependencies:
+      '@sanity/icons': 5.2.1(react@19.2.8)
+      '@sanity/ui': 4.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      lucide-react: 1.34.0(react@19.2.8)
+      react: 19.2.8
+      sanity: 6.11.0(61d9c09ff2805c505dbb19769f6aa9a4)
+    transitivePeerDependencies:
+      - react-dom
+      - styled-components
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true
 
@@ -8759,7 +8763,7 @@ snapshots:
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/ui': 4.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       react: 19.2.8
-      ui5: '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
+      ui5: '@sanity/ui@5.0.0-alpha.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
     transitivePeerDependencies:
       - react-dom
       - styled-components
@@ -8771,7 +8775,7 @@ snapshots:
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/ui': 4.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       react: 19.2.8
-      ui5: '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
+      ui5: '@sanity/ui@5.0.0-alpha.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
     transitivePeerDependencies:
       - react-dom
       - styled-components
@@ -10034,10 +10038,10 @@ snapshots:
       styled-components: 6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       use-effect-event: 2.0.3(react@19.2.8)
 
-  '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@sanity/ui@5.0.0-alpha.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4
-      '@sanity/icons': 3.8.0(react@19.2.8)
+      '@sanity/icons': 5.2.1(react@19.2.8)
       clsx: 2.1.1
       comment-json: 5.0.0
       dialog-closedby-polyfill: 1.3.0
@@ -10114,7 +10118,7 @@ snapshots:
       react-rx: 6.0.0(react@19.2.8)(rxjs@7.8.2)
       rxjs: 7.8.2
       sanity: 6.11.0(61d9c09ff2805c505dbb19769f6aa9a4)
-      ui5: '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
+      ui5: '@sanity/ui@5.0.0-alpha.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
       use-effect-event: 2.0.3(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -12013,10 +12017,6 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.532.0(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-
   lucide-react@1.34.0(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -12733,14 +12733,6 @@ snapshots:
       - '@types/react'
       - react-dom
 
-  sanity-plugin-lucide-icon-picker@1.0.3(@sanity/icons@3.8.0(react@19.2.8))(@sanity/ui@3.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4)):
-    dependencies:
-      '@sanity/icons': 3.8.0(react@19.2.8)
-      '@sanity/ui': 3.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      lucide-react: 0.532.0(react@19.2.8)
-      react: 19.2.8
-      sanity: 6.11.0(61d9c09ff2805c505dbb19769f6aa9a4)
-
   sanity-plugin-media@6.1.6(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.11.0(61d9c09ff2805c505dbb19769f6aa9a4))(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11(@types/node@26.3.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.37.0)(tsx@4.23.12)(yaml@2.9.0))):
     dependencies:
       '@hookform/resolvers': 4.1.3(react-hook-form@7.86.0(react@19.2.8))
@@ -12923,7 +12915,7 @@ snapshots:
       speakingurl: 14.0.1
       styled-components: 6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       swr: 2.5.1(react@19.2.8)
-      ui5: '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
+      ui5: '@sanity/ui@5.0.0-alpha.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
       urlpattern-polyfill: 10.1.0
       use-device-pixel-ratio: 1.1.2(react@19.2.8)
       use-effect-event: 2.0.3(react@19.2.8)
@@ -13073,7 +13065,7 @@ snapshots:
       speakingurl: 14.0.1
       styled-components: 6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       swr: 2.5.1(react@19.2.8)
-      ui5: '@sanity/ui@5.0.0-alpha.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
+      ui5: '@sanity/ui@5.0.0-alpha.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
       urlpattern-polyfill: 10.1.0
       use-device-pixel-ratio: 1.1.2(react@19.2.8)
       use-effect-event: 2.0.3(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -110,3 +110,4 @@ minimumReleaseAgeExclude:
   - next@16.3.3
   - '@tanstack/query-core@5.102.5'
   - '@tanstack/react-query@5.102.5'
+  - '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,13 +35,6 @@ allowBuilds:
 peerDependencyRules:
   allowedVersions:
     sanity-plugin-utils>sanity: ">=5"
-    sanity-plugin-lucide-icon-picker>sanity: ">=5"
-    # This plugin is why apps/studio and @workspace/sanity-blocks hold
-    # @sanity/ui at 3 and @sanity/icons at 3: it imports Menu, Popover,
-    # TrashIcon and friends, which ui 4 / icons 5 moved or dropped, and it
-    # takes them from the Studio as peers, so `sanity build` fails. sanity
-    # itself still ships ui 4 / icons 5 internally, as it did before.
-    sanity-plugin-lucide-icon-picker>@sanity/ui: ">=3"
     sanity-plugin-media>sanity: ">=5"
     sanity-plugin-asset-source-unsplash>sanity: ">=5"
     next-sanity>sanity: ">=5"
@@ -110,4 +103,4 @@ minimumReleaseAgeExclude:
   - next@16.3.3
   - '@tanstack/query-core@5.102.5'
   - '@tanstack/react-query@5.102.5'
-  - '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.0'
+  - '@robotostudio/sanity-plugin-lucide-icon-picker@1.0.2'


### PR DESCRIPTION
## Description

Replaces the unmaintained `sanity-plugin-lucide-icon-picker` with the in-house
[`@robotostudio/sanity-plugin-lucide-icon-picker`](https://www.npmjs.com/package/@robotostudio/sanity-plugin-lucide-icon-picker),
then removes the `@sanity/ui` 3 / `@sanity/icons` 3 pin that the old plugin forced on us.

**The stored format does not change.** Same `lucide-icon` type name, same plain string value,
byte-identical `schema.json`. No content migration, and rollback is free — either plugin can read
the other's values.

What changes is which strings the picker can produce. The old plugin derived names from Lucide's
PascalCase component names with a rule that never inserted a separator before a digit, so it
offered `grid2x2`, `clock1` and `axis3d` where Lucide's names are `grid-2x2`, `clock-1` and
`axis-3d` — **153 of its 2,031 names could not be resolved by the `DynamicIcon` we render with**.
It also still offered the 19 brand icons Lucide dropped in v1, because it bundled its own
`lucide-react@0.532.0`. The replacement takes its catalogue from `iconNames` verbatim — the same
key set `DynamicIcon` looks up — so an unrenderable value cannot be picked.

All 22 icon values currently in the production dataset resolve, so nothing needed rewriting here.

### Why the `@sanity/ui` bump rides along

`pnpm-workspace.yaml` documented the old plugin as the reason `apps/studio` and
`@workspace/sanity-blocks` were held at `@sanity/ui` 3 / `@sanity/icons` 3: it took them from the
Studio as peers and could not run on 4/5. The replacement bundles its own, so the pin has no
reason to exist. Since `sanity` 6.11 already depends on `@sanity/ui` 4.0.6, this *removes* a
duplicate copy of the UI library rather than adding one — the lockfile now has zero references to
either v3 package.

Three kinds of change were needed:

- **`@sanity/icons` 5 empties its root entry**, so all nine icons move to per-icon subpaths. Worth
  knowing: the root still declares each name as `const X: never`, which `tsc` accepts in silence
  while the value is `undefined` at runtime. Biome has no rule for it either. These were verified
  by resolving every import at runtime, not by trusting the typecheck.
- **`useToast` moved to `@sanity/ui/toast`** — same trap.
  `(await import('@sanity/ui')).useToast` is confirmed `undefined` on 4.0.6, so left alone the
  presentation-URL toast would have failed at runtime with every check passing.
- **`@sanity/ui` 4 types `space` as `never`**, so six `<Stack space={n}>` became `gap={n}`. `tsc`
  does catch these — assigning to `never` is an error even though reading one is not.

## Type of change

- [x] Feature
- [x] Refactor

## Testing

Baseline captured on `main` first, so any failure was attributable.

| Check | Result |
|---|---|
| `pnpm check-types` | 8/8 |
| `pnpm lint` | 9/9 |
| `pnpm test` | 280/280 |
| `pnpm build:studio` | pass |
| `pnpm build:web` | pass |
| `pnpm test:e2e` | 5/5 |
| Runtime import resolution | 10/10 migrated imports resolve to real values |
| `sanity schema extract` | byte-identical `schema.json` |
| `lucide-react` duplication | none — plugin and studio share one 1.34.0 instance |

Frontend verified in a browser on both the dev server and the production build: all six
content-driven icons on `/overview` render with real geometry, zero `TriangleAlert` fallbacks.

Studio verified by hand: picker grid, search, selection, the Presentation tool and workspace
switching.

Side effect worth noting: `sanity build` drops from ~63s to ~17s and schema extraction from ~45s
to ~12s, which is the duplicate UI library leaving the bundle graph.

### Not covered by automated checks

Cosmetic surfaces a reviewer may want to click, since a wrong icon subpath renders as a blank
space rather than an error: the slug field (5 of the 6 `space` → `gap` renames live there) and its
copy button, the rich-text toolbar icons, and the structure nav icons.

## Related issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Studio’s Sanity UI and icon libraries to newer versions.
  - Updated the Lucide icon picker integration.
  - Improved compatibility with current Sanity component APIs and icon module structure.

- **Refactor**
  - Standardized spacing configuration across slug fields and validation messages.
  - Updated icon references without changing the visible functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->