### PR TITLE
ROB-2857 : Fix Presentation Preview Flicker From Dead Draft Refresh

### DIFF
--- a/apps/web/src/app/actions/revalidate.ts
+++ b/apps/web/src/app/actions/revalidate.ts
@@ -16,8 +16,9 @@ export async function revalidateSyncTags(unsafeTags: unknown) {
     for (const tag of tags) {
       updateTag(tag);
     }
-    // `updateTag` alone doesn't trigger the router refresh Presentation needs.
-    return "refresh" as const;
+    // No refresh in draft: `updateTag` (with `cacheTag` in live.ts) surfaces the
+    // edit live, and a `router.refresh()` here flashes prefetched sibling routes.
+    return;
   }
 
   for (const tag of tags) {


### PR DESCRIPTION
## Problem

In the Presentation tool (draft mode), editing a document made the live preview **flicker to a different page** — usually `/showcase` — on every keystroke.

## Root cause

`revalidateSyncTags` returned `"refresh"` in its **draft** branch, so `<SanityLive>` fired a full `router.refresh()` on every draft content event.

That was a valid workaround from when `updateTag` had no cache tags to invalidate. `cacheTag(...result.tags)` was later added to `packages/sanity/src/live.ts`, which made targeted invalidation actually work — leaving the `router.refresh()` as **redundant dead code**. Under `cacheComponents`, that per-keystroke refresh races prefetched sibling routes (nav `<Link>`s), which is what paints the wrong page.

## Change

- Drop the draft-branch `return "refresh"`; rely on `updateTag` alone.
- The published branch is unchanged (`revalidateTag(tag, "max")` + `return "refresh"` still repaints open visitor tabs).

## Verification

- `updateTag` (backed by `cacheTag` in `live.ts`) surfaces the editor's own draft edits live **without** the refresh — confirmed in Presentation: edits update in place, no flicker.
- `pnpm --filter web check-types` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Draft-mode content updates now appear live without triggering a full route refresh.
  - Prevented visible flashes in prefetched sibling pages when content is edited.
  - Published-mode revalidation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->