### PR TITLE
ROB-2858 : Honor DRAFTS_WITHOUT_SESSION In The Markdown Route

### DIFF
--- a/apps/web/src/app/api/markdown/route.ts
+++ b/apps/web/src/app/api/markdown/route.ts
@@ -11,7 +11,6 @@ import {
   queryRedirects,
   querySlugPageData,
 } from "@workspace/sanity/query";
-import { draftMode } from "next/headers";
 
 import { fetchBlogIndexPage, parseBlogPageParam } from "@/lib/blog-index";
 import {
@@ -181,12 +180,8 @@ async function findRedirect(
 }
 
 async function resolveFetchOptions(): Promise<DynamicFetchOptions> {
-  const { isEnabled } = await draftMode();
-  if (!isEnabled) {
-    return PUBLISHED;
-  }
-  // Perspective follows draft mode, but stega stays off: its invisible
-  // metadata characters would end up inside the copied Markdown.
+  // Match the page routes' draft/published resolution. stega stays off: its
+  // invisible metadata characters would end up inside the copied Markdown.
   return { ...(await getDynamicFetchOptions()), stega: false };
 }
 


### PR DESCRIPTION
## Problem

In local dev, a draft-only (unpublished) page renders at `/foo`, but its Markdown at `/foo.md` **404s** — so "Copy as Markdown" fails on those pages.

## Root cause

The Markdown route (`apps/web/src/app/api/markdown/route.ts`) resolved draft-vs-published perspective differently from the HTML page routes: it only served drafts when `draftMode().isEnabled`, **ignoring `DRAFTS_WITHOUT_SESSION`**. The page routes serve drafts when `isDraftMode || DRAFTS_WITHOUT_SESSION` (dev), so an unpublished page rendered while its `.md` fell back to `published` and 404'd.

## Change

`resolveFetchOptions` now delegates to `getDynamicFetchOptions()` — which already honors `DRAFTS_WITHOUT_SESSION` — with `stega: false`. Dropped the `if (!isEnabled) return PUBLISHED` early-return and the now-unused `draftMode` import.

## Scope & safety

- Dev-only fix; production and anonymous requests still get **published-only** Markdown (`getDynamicFetchOptions` returns published for non-dev anonymous requests).
- Not a draft leak — the route is now equal to, never looser than, the page routes.

## Verification

- `/another-example.md` (draft-only): **404 → 200**, correct Markdown body.
- No regression: home, pages, nested pages, blog index and posts all still 200; a truly nonexistent `.md` still 404s; redirects still 308.
- `pnpm --filter web check-types` and `lint` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown content now respects the same draft and published content resolution as page routes.
  * Preview and published responses are handled consistently when retrieving markdown content.
  * Removed an incorrect fallback that could force published content in certain requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->