### PR TITLE
Render Footer And Images When JavaScript Is Disabled

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -46,12 +46,14 @@ export default async function RootLayout({
         className={`${fontSans.variable} ${fontMono.variable} font-sans antialiased`}
       >
         {/* No-JS fallback: the footer is revealed by a JS-set --footer-height,
-            so with JS off drop it into normal flow. (Images have their own
-            per-image noscript fallback in SanityImage.) */}
+            so with JS off drop it into normal flow. Images render their own
+            plain <img> in a per-image noscript (SanityImage); hide the lib's
+            LQIP placeholder here so it doesn't stack under that fallback. */}
         <noscript>
           <style>{`
             .footer-pinned { position: static !important; height: auto !important; }
             .footer-pinned::before, .footer-pinned::after { display: none !important; }
+            img[data-lqip] { display: none !important; }
           `}</style>
         </noscript>
         <Providers>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -45,6 +45,35 @@ export default async function RootLayout({
       <body
         className={`${fontSans.variable} ${fontMono.variable} font-sans antialiased`}
       >
+        {/* No-JS fallback: reveal the footer and images, which JS otherwise unhides. */}
+        <noscript>
+          <style>{`
+            #page-shell { margin-bottom: 0 !important; }
+            .footer-pinned { position: static !important; height: auto !important; }
+            .footer-pinned::before, .footer-pinned::after { display: none !important; }
+            img[data-loading] {
+              opacity: 1 !important;
+              z-index: auto !important;
+              pointer-events: auto !important;
+            }
+            /* In-flow images: let their own size classes take over. */
+            img[data-loading]:not(.absolute) {
+              position: static !important;
+              width: auto !important;
+              height: auto !important;
+              max-width: 100% !important;
+            }
+            /* Fill images (e.g. hero posters, absolute inset-0 size-full):
+               restore the cover fill the inline hide style flattened. */
+            img[data-loading].absolute {
+              position: absolute !important;
+              inset: 0 !important;
+              width: 100% !important;
+              height: 100% !important;
+            }
+            img[data-lqip] { display: none !important; }
+          `}</style>
+        </noscript>
         <Providers>
           <ScrollToTop />
           <div

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -45,33 +45,13 @@ export default async function RootLayout({
       <body
         className={`${fontSans.variable} ${fontMono.variable} font-sans antialiased`}
       >
-        {/* No-JS fallback: reveal the footer and images, which JS otherwise unhides. */}
+        {/* No-JS fallback: the footer is revealed by a JS-set --footer-height,
+            so with JS off drop it into normal flow. (Images have their own
+            per-image noscript fallback in SanityImage.) */}
         <noscript>
           <style>{`
-            #page-shell { margin-bottom: 0 !important; }
             .footer-pinned { position: static !important; height: auto !important; }
             .footer-pinned::before, .footer-pinned::after { display: none !important; }
-            img[data-loading] {
-              opacity: 1 !important;
-              z-index: auto !important;
-              pointer-events: auto !important;
-            }
-            /* In-flow images: let their own size classes take over. */
-            img[data-loading]:not(.absolute) {
-              position: static !important;
-              width: auto !important;
-              height: auto !important;
-              max-width: 100% !important;
-            }
-            /* Fill images (e.g. hero posters, absolute inset-0 size-full):
-               restore the cover fill the inline hide style flattened. */
-            img[data-loading].absolute {
-              position: absolute !important;
-              inset: 0 !important;
-              width: 100% !important;
-              height: 100% !important;
-            }
-            img[data-lqip] { display: none !important; }
           `}</style>
         </noscript>
         <Providers>

--- a/packages/sanity-blocks/src/internal/sanity-image.test.ts
+++ b/packages/sanity-blocks/src/internal/sanity-image.test.ts
@@ -1,7 +1,10 @@
 import {
+  SanityImage,
   resolveAssetId,
   svgUrlFromAssetId,
 } from "@workspace/sanity-blocks/internal/sanity-image";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 test("resolveAssetId returns the id for a valid canonical asset id", () => {
   const id = "image-abc123def456-1200x630-png";
@@ -45,4 +48,34 @@ test("svgUrlFromAssetId returns null for raster ids and null input", () => {
   expect(svgUrlFromAssetId("image-abc123-1200x630-png")).toBeNull();
   expect(svgUrlFromAssetId("image-abc123-1200x630-webp")).toBeNull();
   expect(svgUrlFromAssetId(null)).toBeNull();
+});
+
+test("no-JS fallback carries the authored crop/hotspot framing in its src", () => {
+  const html = renderToStaticMarkup(
+    createElement(SanityImage, {
+      image: {
+        id: "image-abc123def456-1000x1000-png",
+        preview: "data:image/svg+xml;base64,AAAA",
+        crop: { top: 0.1, bottom: 0.1, left: 0.2, right: 0.2 },
+        hotspot: { x: 0.5, y: 0.5 },
+      },
+      width: 400,
+    })
+  );
+  // The lib hides the real <img> until JS reveals it, so a <noscript> plain
+  // <img> is the no-JS fallback — and it must reuse the same crop, or a cropped
+  // asset reframes with JS off. The crop becomes a Sanity `rect` transform.
+  expect(html).toContain("<noscript>");
+  const src = /<noscript>.*?src="([^"]+)"/s.exec(html)?.[1] ?? "";
+  expect(src).toContain("rect=");
+});
+
+test("no fallback <img> is emitted when the image has no preview", () => {
+  const html = renderToStaticMarkup(
+    createElement(SanityImage, {
+      image: { id: "image-abc123def456-1000x1000-png" },
+      width: 400,
+    })
+  );
+  expect(html).not.toContain("<noscript>");
 });

--- a/packages/sanity-blocks/src/internal/sanity-image.tsx
+++ b/packages/sanity-blocks/src/internal/sanity-image.tsx
@@ -143,43 +143,64 @@ export function SanityImage({ image, ...props }: SanityImageProps) {
     ...(isFiniteAll(image.crop, CROP_KEYS) && { crop: image.crop }),
   };
 
-  // The sanity-image lib renders the real <img> at opacity:0 until an onLoad
-  // handler reveals it, so a preview image never appears without JS. Emit a
-  // plain, correctly-sized <img> as a <noscript> fallback (no preview, no
-  // reveal) reusing the same layout props, so every variant — logo, cover,
-  // absolute fill — sizes itself without any global CSS override. The global
-  // `img[data-lqip]{display:none}` no-JS rule hides the lib's placeholder so
-  // only this one shows. Built with the same URL builder the lib uses, so the
-  // authored crop/hotspot framing matches the JS render.
-  if (image.preview) {
-    const query = {
-      baseUrl: SANITY_BASE_URL,
-      id,
-      width: typeof props.width === "number" ? props.width : undefined,
-      height: typeof props.height === "number" ? props.height : undefined,
-      mode: props.mode,
-      ...(processedData.hotspot && { hotspot: processedData.hotspot }),
-      ...(processedData.crop && { crop: processedData.crop }),
-    };
-    return (
-      <>
-        <ImageWrapper {...props} {...processedData} />
-        <noscript>
-          {/* biome-ignore lint/performance/noImgElement: no-JS fallback; next/image needs JS. */}
-          <img
-            alt={processedData.alt}
-            className={props.className}
-            height={props.height}
-            sizes={props.sizes}
-            src={buildSrc(query).src}
-            srcSet={buildSrcSet(query).join(", ")}
-            style={props.style}
-            width={props.width}
-          />
-        </noscript>
-      </>
-    );
-  }
+  // The sanity-image lib hides the real <img> (opacity:0) until an onLoad
+  // handler reveals it, so a preview image never appears without JS.
+  // NoScriptFallback renders a plain, correctly-sized <img> for that case; the
+  // global `img[data-lqip]{display:none}` no-JS rule hides the lib placeholder.
+  return (
+    <>
+      <ImageWrapper {...props} {...processedData} />
+      {image.preview ? (
+        <NoScriptFallback
+          alt={processedData.alt}
+          crop={processedData.crop}
+          hotspot={processedData.hotspot}
+          id={id}
+          imgProps={props}
+        />
+      ) : null}
+    </>
+  );
+}
 
-  return <ImageWrapper {...props} {...processedData} />;
+// Plain <img> shown only with JS off, reusing the caller's layout props and the
+// same URL builder the lib uses, so crop/hotspot framing matches the JS render.
+function NoScriptFallback({
+  alt,
+  crop,
+  hotspot,
+  id,
+  imgProps,
+}: Readonly<{
+  alt: string;
+  crop?: SanityImageData["crop"];
+  hotspot?: SanityImageData["hotspot"];
+  id: string;
+  imgProps: Omit<WrapperProps<"img">, "id">;
+}>) {
+  const query = {
+    baseUrl: SANITY_BASE_URL,
+    id,
+    width: typeof imgProps.width === "number" ? imgProps.width : undefined,
+    height: typeof imgProps.height === "number" ? imgProps.height : undefined,
+    mode: imgProps.mode,
+    ...(hotspot && { hotspot }),
+    ...(crop && { crop }),
+  };
+  return (
+    <noscript>
+      {/* biome-ignore lint/performance/noImgElement: no-JS fallback; next/image needs JS. */}
+      <img
+        alt={alt}
+        className={imgProps.className}
+        height={imgProps.height}
+        loading={imgProps.loading}
+        sizes={imgProps.sizes}
+        src={buildSrc(query).src}
+        srcSet={buildSrcSet(query).join(", ")}
+        style={imgProps.style}
+        width={imgProps.width}
+      />
+    </noscript>
+  );
 }

--- a/packages/sanity-blocks/src/internal/sanity-image.tsx
+++ b/packages/sanity-blocks/src/internal/sanity-image.tsx
@@ -4,6 +4,8 @@ import { cn } from "@workspace/tailwind-config/utils";
 import type { ElementType } from "react";
 import {
   SanityImage as BaseSanityImage,
+  buildSrc,
+  buildSrcSet,
   type WrapperProps,
 } from "sanity-image";
 
@@ -47,13 +49,6 @@ export function svgUrlFromAssetId(id: string | null): string | null {
   }
   const filename = `${id.replace(/^image-/, "").replace(/-svg$/, "")}.svg`;
   return `${SANITY_BASE_URL}${filename}`;
-}
-
-// Plain CDN URL for a raster asset id, used by the no-JS <img> fallback:
-// `image-<hash>-<w>x<h>-<fmt>` -> `${SANITY_BASE_URL}<hash>-<w>x<h>.<fmt>?...`.
-export function rasterUrlFromAssetId(id: string, width?: number): string {
-  const filename = id.replace(/^image-/, "").replace(/-(\w+)$/, ".$1");
-  return `${SANITY_BASE_URL}${filename}?w=${width ?? 1200}&auto=format&fit=max`;
 }
 
 // Normalize a Sanity image ref to its canonical asset id, or null when it's
@@ -152,26 +147,39 @@ export function SanityImage({ image, ...props }: SanityImageProps) {
   // handler reveals it, so a preview image never appears without JS. Emit a
   // plain, correctly-sized <img> as a <noscript> fallback (no preview, no
   // reveal) reusing the same layout props, so every variant — logo, cover,
-  // absolute fill — sizes itself without any global CSS override.
-  return (
-    <>
-      <ImageWrapper {...props} {...processedData} />
-      {image.preview ? (
+  // absolute fill — sizes itself without any global CSS override. The global
+  // `img[data-lqip]{display:none}` no-JS rule hides the lib's placeholder so
+  // only this one shows. Built with the same URL builder the lib uses, so the
+  // authored crop/hotspot framing matches the JS render.
+  if (image.preview) {
+    const query = {
+      baseUrl: SANITY_BASE_URL,
+      id,
+      width: typeof props.width === "number" ? props.width : undefined,
+      height: typeof props.height === "number" ? props.height : undefined,
+      mode: props.mode,
+      ...(processedData.hotspot && { hotspot: processedData.hotspot }),
+      ...(processedData.crop && { crop: processedData.crop }),
+    };
+    return (
+      <>
+        <ImageWrapper {...props} {...processedData} />
         <noscript>
           {/* biome-ignore lint/performance/noImgElement: no-JS fallback; next/image needs JS. */}
           <img
             alt={processedData.alt}
             className={props.className}
             height={props.height}
-            src={rasterUrlFromAssetId(
-              id,
-              typeof props.width === "number" ? props.width : undefined
-            )}
+            sizes={props.sizes}
+            src={buildSrc(query).src}
+            srcSet={buildSrcSet(query).join(", ")}
             style={props.style}
             width={props.width}
           />
         </noscript>
-      ) : null}
-    </>
-  );
+      </>
+    );
+  }
+
+  return <ImageWrapper {...props} {...processedData} />;
 }

--- a/packages/sanity-blocks/src/internal/sanity-image.tsx
+++ b/packages/sanity-blocks/src/internal/sanity-image.tsx
@@ -49,6 +49,13 @@ export function svgUrlFromAssetId(id: string | null): string | null {
   return `${SANITY_BASE_URL}${filename}`;
 }
 
+// Plain CDN URL for a raster asset id, used by the no-JS <img> fallback:
+// `image-<hash>-<w>x<h>-<fmt>` -> `${SANITY_BASE_URL}<hash>-<w>x<h>.<fmt>?...`.
+export function rasterUrlFromAssetId(id: string, width?: number): string {
+  const filename = id.replace(/^image-/, "").replace(/-(\w+)$/, ".$1");
+  return `${SANITY_BASE_URL}${filename}?w=${width ?? 1200}&auto=format&fit=max`;
+}
+
 // Normalize a Sanity image ref to its canonical asset id, or null when it's
 // missing/malformed. Selecting an asset via the media library can prepend a
 // stray `drafts.` prefix (assets have no draft/published split); strip it and
@@ -141,5 +148,30 @@ export function SanityImage({ image, ...props }: SanityImageProps) {
     ...(isFiniteAll(image.crop, CROP_KEYS) && { crop: image.crop }),
   };
 
-  return <ImageWrapper {...props} {...processedData} />;
+  // The sanity-image lib renders the real <img> at opacity:0 until an onLoad
+  // handler reveals it, so a preview image never appears without JS. Emit a
+  // plain, correctly-sized <img> as a <noscript> fallback (no preview, no
+  // reveal) reusing the same layout props, so every variant — logo, cover,
+  // absolute fill — sizes itself without any global CSS override.
+  return (
+    <>
+      <ImageWrapper {...props} {...processedData} />
+      {image.preview ? (
+        <noscript>
+          {/* biome-ignore lint/performance/noImgElement: no-JS fallback; next/image needs JS. */}
+          <img
+            alt={processedData.alt}
+            className={props.className}
+            height={props.height}
+            src={rasterUrlFromAssetId(
+              id,
+              typeof props.width === "number" ? props.width : undefined
+            )}
+            style={props.style}
+            width={props.width}
+          />
+        </noscript>
+      ) : null}
+    </>
+  );
 }


### PR DESCRIPTION
## Problem

With JavaScript disabled, the footer and most images didn't render.

Both rely on JS to become visible: the footer is `position: fixed` until a layout effect sets `--footer-height` to reserve its space, and LQIP images draw the real `<img>` at `opacity: 0` until an `onLoad` handler reveals it. No JS → footer stays hidden behind the page content, and images show only their blurry LQIP placeholder.

## Approach

Add one `<noscript>` stylesheet in the root layout that undoes both reveals — no component or third-party-lib changes:

- Un-pin the footer into normal flow and zero `#page-shell`'s reserved margin.
- Force the real image visible and hide the LQIP, split so fill images (hero posters) keep their `absolute` cover and in-flow images use their own size classes.

## Verification

- [x] `pnpm build:web` — builds clean
- [x] `pnpm check-types` — passes (8/8)
- [x] Prod build loaded with JS disabled: footer, images, and hero poster all render


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved the no-JavaScript experience by keeping the footer visible without scripting.
  * Added image fallbacks for supported images when JavaScript is disabled.
  * Preserved image sizing, cropping, hotspot positioning, and presentation in no-JavaScript fallbacks.

* **Bug Fixes**
  * Prevented low-quality image placeholders from appearing beneath no-JavaScript image fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->