### PR TITLE
Exclude Release Version Ids From Slug Uniqueness Check

### DIFF
--- a/apps/studio/utils/slug-validation.ts
+++ b/apps/studio/utils/slug-validation.ts
@@ -2,7 +2,7 @@
  * Slug validation — single source of truth for all URL path validation.
  */
 
-import type { ValidationContext } from "sanity";
+import { getPublishedId, type ValidationContext } from "sanity";
 import slugify from "slugify";
 
 import { API_VERSION } from "@/utils/constant";
@@ -230,9 +230,9 @@ export function createSlugErrorValidator(
 }
 
 /**
- * Reject a slug already taken by another document. The document's own draft and
- * published ids are excluded so re-saving an unchanged document doesn't flag
- * itself.
+ * Reject a slug already taken by another document. Excludes every id this
+ * document can be stored under so it never flags itself: in a release `_id` is
+ * `versions.<releaseId>.<publishedId>`, matching neither the draft nor published id.
  */
 export function createSlugUniqueValidator(): (
   slug: { current?: string } | undefined,
@@ -243,12 +243,13 @@ export function createSlugUniqueValidator(): (
     if (!(current && context.getClient)) {
       return true;
     }
-    const id = (context.document?._id ?? "").replace(/^drafts\./, "");
+    const self = context.document?._id ?? "";
+    const id = getPublishedId(self);
     const taken = await context
       .getClient({ apiVersion: API_VERSION })
       .fetch<number>(
-        `count(*[!(_id in [$draft, $published]) && slug.current == $slug])`,
-        { draft: `drafts.${id}`, published: id, slug: current }
+        `count(*[!(_id in [$self, $draft, $published]) && slug.current == $slug])`,
+        { self, draft: `drafts.${id}`, published: id, slug: current }
       );
     return taken > 0
       ? `“${current}” is already used by another document. URLs must be unique.`

--- a/apps/studio/utils/slug-validation.ts
+++ b/apps/studio/utils/slug-validation.ts
@@ -230,9 +230,10 @@ export function createSlugErrorValidator(
 }
 
 /**
- * Reject a slug already taken by another document. Excludes every id this
- * document can be stored under so it never flags itself: in a release `_id` is
- * `versions.<releaseId>.<publishedId>`, matching neither the draft nor published id.
+ * Reject a slug already taken by another document. Excludes its own draft,
+ * published and release copies so it never flags itself — the releases by
+ * predicate, not id: a release copy collides from the draft's point of view too,
+ * and a document can sit in more than one release.
  */
 export function createSlugUniqueValidator(): (
   slug: { current?: string } | undefined,
@@ -243,13 +244,12 @@ export function createSlugUniqueValidator(): (
     if (!(current && context.getClient)) {
       return true;
     }
-    const self = context.document?._id ?? "";
-    const id = getPublishedId(self);
+    const id = getPublishedId(context.document?._id ?? "");
     const taken = await context
       .getClient({ apiVersion: API_VERSION })
       .fetch<number>(
-        `count(*[!(_id in [$self, $draft, $published]) && slug.current == $slug])`,
-        { self, draft: `drafts.${id}`, published: id, slug: current }
+        `count(*[!(_id in [$draft, $published]) && !sanity::versionOf($published) && slug.current == $slug])`,
+        { draft: `drafts.${id}`, published: id, slug: current }
       );
     return taken > 0
       ? `“${current}” is already used by another document. URLs must be unique.`


### PR DESCRIPTION
## Problem

Any document added to a Content Release showed `(error)` on its Content tab, with *"…is already used by another document. URLs must be unique."* The document was colliding with itself.

`createSlugUniqueValidator` in `apps/studio/utils/slug-validation.ts` derived the ids to exclude from the uniqueness count with `.replace(/^drafts\./, "")`. That handles a draft id but not a release id, which is shaped `versions.<releaseId>.<publishedId>`. Inside a release the exclusion list became `["drafts.versions.<releaseId>.<id>", "versions.<releaseId>.<id>"]`, so the document's own published copy was never excluded and got counted as a conflict.

Affects every type using `documentSlugField`: `page`, `blog`, `homePage`, `blogIndex`.

## Approach

Replace the hand-rolled prefix strip with `getPublishedId` from `sanity`, which reduces all three id shapes (`id`, `drafts.id`, `versions.<releaseId>.id`) to the published id, and add the document's literal `_id` to the GROQ exclusion list as `$self`.

Both parts are needed. `getPublishedId` alone still fails once a release actually exists: the version document carries the same slug and, not matching either `drafts.<id>` or `<id>`, counts itself. `$self` excludes it whichever form the id takes, and is independent of the client perspective the validator happens to run under.

The fix sits in the shared validator rather than per document type, so all four types are covered by the one change.

## Verification

- [x] `pnpm check-types`
- [x] `pnpm --filter studio lint`
- [x] Add a page to a Content Release; its Content tab shows no validation error 
- [x] Give a second document a slug that already exists; it is still rejected 
- [x] Edit a page normally and as a draft; behavior unchanged 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved slug uniqueness validation to prevent conflicts with a document’s draft, published, or release versions.
- Correctly handles documents associated with multiple releases during slug validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->