### PR TITLE
Record Video For Failed Presentation E2E Runs

### DIFF
--- a/apps/web/playwright.presentation.config.ts
+++ b/apps/web/playwright.presentation.config.ts
@@ -67,6 +67,16 @@ export default defineConfig({
     // the Editor token on each API call — the report is uploaded as an
     // artifact of a public repo.
     trace: isCI ? "off" : "retain-on-failure",
+    // On in CI, unlike the trace above: a video records the viewport, never a
+    // request header, so it carries no token — and with the trace off it is
+    // the only CI artifact showing the loop run.
+    video: {
+      mode: "retain-on-failure",
+      // Labels every frame with the spec and test, and annotates actions. The
+      // failing assertion is never shown: `expect` polling draws nothing, so
+      // that stays in the error panel and the trace.
+      show: { actions: { cursor: "pointer" }, test: { level: "step" } },
+    },
     screenshot: "only-on-failure",
     navigationTimeout: 30_000,
   },

--- a/apps/web/tests/e2e/presentation-singletons.spec.ts
+++ b/apps/web/tests/e2e/presentation-singletons.spec.ts
@@ -183,8 +183,27 @@ const visit = async (context: BrowserContext, path: string) => {
   return tab;
 };
 
+/**
+ * The Studio form's value is browser state — `fillStable` asserts the input,
+ * not a committed mutation. The preview and Publish both read the dataset, so
+ * assert the edit landed there first; otherwise both act on the pre-edit draft.
+ */
+const draftHas = (id: SingletonId, value: string) =>
+  expect
+    .poll(
+      soft(
+        async () =>
+          JSON.stringify(await client.getDocument(`drafts.${id}`)) ?? ""
+      ),
+      { timeout: SYNC_TIMEOUT }
+    )
+    .toContain(value);
+
 /** Publish through the Studio and wait for the dataset to carry `value`. */
 const publish = async (studio: Page, id: SingletonId, value: string) => {
+  // Publishing before the draft lands ships the pre-edit document, and the
+  // poll below then times out on content that was never published.
+  await draftHas(id, value);
   await studio.getByTestId("action-publish").click();
   await expect
     .poll(
@@ -309,6 +328,7 @@ test("footer: draft subtitle shows in Presentation only, publish puts it on ever
   const subtitle = studio.getByTestId("field-subtitle").getByRole("textbox");
   await expect(subtitle).toBeVisible({ timeout: LIVE_TIMEOUT });
   await fillStable(subtitle, footerSubtitle);
+  await draftHas("footer", footerSubtitle);
   await expect(
     preview(studio).getByRole("contentinfo").getByText(footerSubtitle)
   ).toBeVisible({ timeout: LIVE_TIMEOUT });
@@ -339,6 +359,7 @@ test("settings: site title reaches <title> on / after publish", async ({
   const title = studio.getByTestId("field-siteTitle").getByRole("textbox");
   await expect(title).toBeVisible({ timeout: LIVE_TIMEOUT });
   await fillStable(title, siteTitle);
+  await draftHas("settings", siteTitle);
   // Metadata is fetched without stega, so the draft title reads clean.
   const frame = studio.frame({ url: (url) => url.pathname === "/" });
   expect(frame, "preview iframe is not on /").not.toBeNull();


### PR DESCRIPTION
## Context / Intent

Two changes to the Presentation e2e suite: keep a video when a test fails, and stop the singleton tests racing the Studio's save.

**Videos.** When the suite fails in CI, the report carries a screenshot and an accessibility snapshot and nothing else. `trace` is deliberately off in CI — it records every request header, and the Studio sends the Editor token on each API call into an artifact of a public repo — and `video` was left at its default of `off`. On the failed run of PR #471 the `playwright-report-presentation` artifact held 4 PNGs, 2 `error-context.md` and zero videos. A still frame is thin evidence for a suite whose subject is a Studio → website loop unfolding over time.

**The singleton race.** `presentation-singletons.spec.ts` flaked in 2 of 4 full-suite runs, on three different tests (`:200`, `:300`, `:330`), never when the file runs alone. The cause is that `fillStable` asserts the form input, which is browser state, while the Studio submits the mutation separately. The preview and the Publish button both read the dataset, so a test that trusts the input runs ahead of the write: the preview shows the pre-edit draft, and Publish ships pre-edit content. A retained video caught it directly — the Subtitle field held the E2E text and then reverted to the seed value.

## Approach

**`playwright.presentation.config.ts`** — `video: retain-on-failure` in `use`, beside `trace`. It records every run but keeps only failures, so a green run uploads nothing, and a failed run's video survives a passing retry, which matters with `retries: 1`. On in CI where `trace` is not: a video records the viewport, never a request header, so it carries no token. `show` labels each frame with the spec and test. No workflow change — the HTML reporter copies the `.webm` into `playwright-report/data/`, which `e2e.yml` already uploads.

**`presentation-singletons.spec.ts`** — a `draftHas` helper polls the dataset until `drafts.<singleton>` carries the new value, called in `publish()` before the click and after each `fillStable` before the preview assertions. One guard in the shared helper rather than a longer timeout in whichever test flaked last, which would only relocate the flake — as it already has, three times.

The video shows what the app was doing, not which assertion failed: `expect` polling draws nothing on screen. That stays in the report's error panel and, locally, the trace.

## Verification

Video behaviour, all observed:

- [x] a failing test leaves a `.webm` under `playwright-report/data/`; 47 passes produced none
- [x] CI: [run 34330376252](https://github.com/robotostudio/turbo-start-sanity/actions/runs/34330376252) failed and its artifact carries 2 `.webm` (1.05 MB, 1.29 MB) against 0 on #471
- [x] `npx biome lint` and type check clean locally; `Lint, Format, Type Check & Tests` green in CI
- [x] full suite green on the branch as it now stands — CI [run 34334679295](https://github.com/robotostudio/turbo-start-sanity/actions/runs/34334679295)


## Additional notes

- Videos are 800×450 VP8, roughly 340 KB–1.3 MB per failed test, against the ~12 MB the report artifact already weighs.
- Only the fixture `context` is recorded. Anonymous-visitor tabs from `browser.newContext()` get no video, since options in `use` do not reach manually-created contexts.

