### PR TITLE
Add Inline Text Editing To The Presentation Preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,38 @@ All frontend types derive from generated Sanity types. `apps/web/src/types.ts` e
 ### Visual Editing & Live Preview
 
 - Sanity Presentation Tool configured in `sanity.config.ts` with `presentationTool`
-- Next.js uses `VisualEditing` from `next-sanity/visual-editing` in layout (draft mode only)
+- Next.js renders `VisualEditingLayer` (`VisualEditing` from `next-sanity/visual-editing` plus this app's overlay components) in layout (draft mode only)
 - `createDataAttribute` used throughout page builder for click-to-edit in Presentation
 - `SanityLive` component enables automatic content revalidation
+
+#### Double-click to type (custom Presentation overlay)
+
+`apps/web/src/components/overlay-components.tsx` is the resolver handed to
+`<VisualEditing components={...} />` through `visual-editing-layer.tsx` (its own
+client component, because a function cannot cross the server/client boundary).
+It returns `InlineText` when `isInlineEditable` in `inline-text.tsx` allows it:
+the element holds a single text node, sits outside any link or button (with
+the overlay toggled off, a click to move the caret would follow the link), and
+either
+
+- **Plain strings**: carries the bare `data-inline-edit` flag over a `string` field. Not `text`, which can hold several lines while Enter saves. `BlockEyebrow`, `BlockHeader`'s title and each block's own plain-string titles, subtitles, captions and testimonial author lines carry it. Opt-in, because the resolver also sees every nav link, button label and badge
+- **Rich text**: has a Portable Text span path (`…children[_key=="s"].text`). The words in a one-span paragraph, or in the bold/italic run inside one, can be typed over. Plain runs in a paragraph that also has marks, and marks, links and new paragraphs themselves, stay in the Studio form
+
+`inline-text.tsx` makes the element `contentEditable="plaintext-only"` on
+double-click and saves once on blur through `useDocuments()`, to the overlay
+node's own `id` and `path`. Sanity ships nothing official for inline typing;
+this is custom on that documented API. The rules that keep typing and page
+updates from trampling each other (strip stega first, save only on blur, put
+typed text back over a render, rewrite React's text node in place, restore on
+cancel, empty or a failed save, end without saving if React restructures the
+text mid-edit) live in the `startEditing` docblock. Saving is last-write-wins,
+as in the Studio form. Never under a release: `useDocuments` always writes to
+`drafts.<id>`, so the edit would land outside the version on screen. Text from
+the published document stays editable, because a page with no draft renders
+from it and the first save creates the draft.
+
+Visitors never mount any of it: `VisualEditingLayer` renders only in draft
+mode, and the `data-inline-edit` attribute is inert outside Presentation.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,11 +165,10 @@ All frontend types derive from generated Sanity types. `apps/web/src/types.ts` e
 `<VisualEditing components={...} />` through `visual-editing-layer.tsx` (its own
 client component, because a function cannot cross the server/client boundary).
 It returns `InlineText` when `isInlineEditable` in `inline-text.tsx` allows it:
-the element holds a single text node, sits outside any link or button (with
-the overlay toggled off, a click to move the caret would follow the link), and
-either
+the element holds a single text node, sits outside any link, button, summary
+or label (the click capture would swallow their handlers), and either
 
-- **Plain strings**: carries the bare `data-inline-edit` flag over a `string` field. Not `text`, which can hold several lines while Enter saves. `BlockEyebrow`, `BlockHeader`'s title and each block's own plain-string titles, subtitles, captions and testimonial author lines carry it. Opt-in, because the resolver also sees every nav link, button label and badge
+- **Plain strings**: carries the bare `data-inline-edit` flag over a `string` field. Never flag a multi-line `text` field: nothing at runtime can tell the two apart, Enter saves, and a paste collapses newlines. `BlockEyebrow`, `BlockHeader`'s title and each block's own plain-string titles, subtitles, captions and testimonial author lines carry it. Opt-in, because the resolver also sees every nav link, button label and badge
 - **Rich text**: has a Portable Text span path (`…children[_key=="s"].text`). The words in a one-span paragraph, or in the bold/italic run inside one, can be typed over. Plain runs in a paragraph that also has marks, and marks, links and new paragraphs themselves, stay in the Studio form
 
 `inline-text.tsx` makes the element `contentEditable="plaintext-only"` on
@@ -178,7 +177,9 @@ node's own `id` and `path`. Sanity ships nothing official for inline typing;
 this is custom on that documented API. The rules that keep typing and page
 updates from trampling each other (strip stega first, save only on blur, put
 typed text back over a render, rewrite React's text node in place, restore on
-cancel, empty or a rejected patch, end without saving if React restructures the
+cancel, empty or a locally rejected patch (the Studio's own write is
+fire-and-forget, so a server rejection is not reported back), end without
+saving if React restructures the
 text mid-edit, clean up if the element is removed) live as comments in
 `inline-text.tsx`. No real click on an editable element reaches the overlay: a
 click opening the field makes the Studio focus its input, which ends an edit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,12 +178,14 @@ node's own `id` and `path`. Sanity ships nothing official for inline typing;
 this is custom on that documented API. The rules that keep typing and page
 updates from trampling each other (strip stega first, save only on blur, put
 typed text back over a render, rewrite React's text node in place, restore on
-cancel, empty or a failed save, end without saving if React restructures the
-text mid-edit) live in the `startEditing` docblock. Saving is last-write-wins,
-as in the Studio form. Never under a release: `useDocuments` always writes to
-`drafts.<id>`, so the edit would land outside the version on screen. Text from
-the published document stays editable, because a page with no draft renders
-from it and the first save creates the draft.
+cancel, empty or a rejected patch, end without saving if React restructures the
+text mid-edit, clean up if the element is removed) live as comments in
+`inline-text.tsx`. Saving is last-write-wins, as in the Studio form. Inline
+editing is on only when the preview's perspective is drafts: `LivePreviewLayer`
+passes that to `VisualEditingLayer`, because saves always write `drafts.<id>`,
+which a published or release preview never shows. In a drafts preview, text
+from the published document stays editable, because a page with no draft
+renders from it and the first save creates the draft.
 
 Visitors never mount any of it: `VisualEditingLayer` renders only in draft
 mode, and the `data-inline-edit` attribute is inert outside Presentation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,11 @@ updates from trampling each other (strip stega first, save only on blur, put
 typed text back over a render, rewrite React's text node in place, restore on
 cancel, empty or a rejected patch, end without saving if React restructures the
 text mid-edit, clean up if the element is removed) live as comments in
-`inline-text.tsx`. Saving is last-write-wins, as in the Studio form. Inline
+`inline-text.tsx`. No real click on an editable element reaches the overlay: a
+click opening the field makes the Studio focus its input, which ends an edit
+mid-word. A single click is replayed after the double-click window, and Enter
+opens the field with the saved value. Saving is last-write-wins, as in the
+Studio form. Inline
 editing is on only when the preview's perspective is drafts: `LivePreviewLayer`
 passes that to `VisualEditingLayer`, because saves always write `drafts.<id>`,
 which a published or release preview never shows. In a drafts preview, text

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@sanity/client": "catalog:",
+    "@sanity/mutate": "^0.18.1",
     "@sanity/visual-editing": "^6.1.1",
     "@tanstack/react-query": "^5.102.5",
     "@vercel/analytics": "^2.0.1",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,6 @@ import {
 } from "@workspace/sanity/live";
 import { Geist, Geist_Mono } from "next/font/google";
 import { draftMode } from "next/headers";
-import { VisualEditing } from "next-sanity/visual-editing";
 import { Suspense } from "react";
 import { preconnect, prefetchDNS } from "react-dom";
 
@@ -20,6 +19,7 @@ import { PreviewBar } from "@/components/preview-bar";
 import { Providers } from "@/components/providers";
 import { ScrollToTop } from "@/components/scroll-to-top";
 import { StickyFooter } from "@/components/sticky-footer";
+import { VisualEditingLayer } from "@/components/visual-editing-layer";
 import { getGithubStars } from "@/lib/github-stars";
 import { getNavigationData } from "@/lib/navigation";
 
@@ -108,7 +108,7 @@ async function LivePreviewLayer() {
       {isDraftMode && (
         <>
           <PreviewBar />
-          <VisualEditing />
+          <VisualEditingLayer />
         </>
       )}
     </>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -102,13 +102,14 @@ export default async function RootLayout({
  */
 async function LivePreviewLayer() {
   const { isEnabled: isDraftMode } = await draftMode();
+  const { perspective } = await getDynamicFetchOptions();
   return (
     <>
       <SanityLive action={revalidateSyncTags} includeDrafts={isDraftMode} />
       {isDraftMode && (
         <>
           <PreviewBar />
-          <VisualEditingLayer />
+          <VisualEditingLayer inlineEditing={perspective === "drafts"} />
         </>
       )}
     </>

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { at, set } from "@sanity/mutate";
+import type { OverlayComponent } from "@sanity/visual-editing/react";
+import { useDocuments } from "@sanity/visual-editing/react";
+import { Logger } from "@workspace/logger";
+import { stegaClean } from "next-sanity";
+import { useEffect } from "react";
+
+const logger = new Logger("inline-text");
+
+/** Set by a block on an element that renders one plain string field. */
+const EDIT_ATTR = "data-inline-edit";
+
+/** A Portable Text span's text, `…[_key=="b"].children[_key=="s"].text`: its
+ * own plain string, so its words are typeable. Marks, links and paragraph
+ * breaks stay in the Studio form. */
+const SPAN_TEXT = /\.children\[_key=="[^"]+"\]\.text$/;
+
+/**
+ * Whether double-click typing arms here. Opt-in, because the resolver also
+ * sees every nav link, button label and badge:
+ * - a flagged `string` element (not `text`: it can hold several lines, and
+ *   Enter saves), or
+ * - a Portable Text span whose element holds only its text: a one-span
+ *   paragraph, or the bold/italic run inside one. A mixed paragraph renders
+ *   its plain runs straight into the `<p>`, so those have no element to type in.
+ * Never inside a link or button: with the overlay toggled off its click
+ * capture is gone, so a click to move the caret would follow the link.
+ */
+export function isInlineEditable(
+  element: Element,
+  path: string,
+  type?: string
+) {
+  const onlyText =
+    element.childNodes.length === 1 && element.firstChild instanceof Text;
+  if (!onlyText || element.closest("a, button")) {
+    return false;
+  }
+  return element.hasAttribute(EDIT_ATTR)
+    ? type === "string"
+    : SPAN_TEXT.test(path);
+}
+
+/** Caret position as a character offset, so it survives the text being
+ * rewritten under it. */
+function caretOffset(element: HTMLElement): number | null {
+  const selection = element.ownerDocument.defaultView?.getSelection();
+  if (!selection?.rangeCount || !element.contains(selection.anchorNode)) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  const upToCaret = range.cloneRange();
+  upToCaret.selectNodeContents(element);
+  upToCaret.setEnd(range.endContainer, range.endOffset);
+  return upToCaret.toString().length;
+}
+
+function placeCaret(element: HTMLElement, offset: number) {
+  const range = element.ownerDocument.createRange();
+  const text = element.firstChild;
+  if (text instanceof Text) {
+    range.setStart(text, Math.min(offset, text.length));
+    range.collapse(true);
+  } else {
+    range.selectNodeContents(element);
+    range.collapse(false);
+  }
+  const selection = element.ownerDocument.defaultView?.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+/**
+ * Turns one element into a text field until blur, then saves once. Imperative
+ * and detached from React: the overlay component unmounts when the pointer
+ * leaves, so an effect cleanup would end the session mid-sentence.
+ *
+ * - Strip stega first: it trails the text invisibly, so Backspace deleted
+ *   nothing visible for dozens of presses.
+ * - Save only on blur: each save re-renders, and a render overwrites the
+ *   screen, so typed characters vanished and came back.
+ * - A render landing mid-edit (the last save's refresh, a Studio edit) gets
+ *   the typed text put back over it; Escape shows the newest render.
+ * - Rewrite React's text node in place, never swap it: Portable Text spans are
+ *   nodes React holds on to, and it would later update or remove a stray one.
+ * - No save, or a failed one: restore React's text with its stega, so the page
+ *   never shows a value the document lacks and the overlay finds it again.
+ * - React removes its node mid-edit: end without saving or touching its DOM.
+ */
+function startEditing(
+  element: HTMLElement,
+  save: (text: string) => Promise<unknown>
+) {
+  const own = element.firstChild;
+  if (!(own instanceof Text)) {
+    return;
+  }
+  const show = (text: string) => {
+    own.nodeValue = text;
+    // Typing can leave the browser's own nodes in place of React's.
+    if (element.firstChild !== own || element.childNodes.length > 1) {
+      element.replaceChildren(own);
+    }
+  };
+
+  // What React last wrote, stega included.
+  let rendered = own.nodeValue ?? "";
+  let typed = stegaClean(rendered);
+  let caret = typed.length;
+  let edited = false;
+  let typing = false;
+  let composing = false;
+  let cancelled = false;
+  let aborted = false;
+
+  // The browser may swap React's node while editing (a paste over a selection
+  // does); put it back, so React's later updates land on a node still in the
+  // page and the removal check below never mistakes the swap for React's.
+  const keepOwnNode = () => {
+    if (element.firstChild === own && element.childNodes.length === 1) {
+      return;
+    }
+    const offset = caretOffset(element) ?? caret;
+    typed = element.textContent ?? "";
+    show(typed);
+    placeCaret(element, offset);
+  };
+
+  const onRender = () => {
+    // React removed its node (span restructured, field cleared): the DOM is
+    // React's now, and the path may no longer exist.
+    if (!element.contains(own)) {
+      aborted = true;
+      element.blur();
+      return;
+    }
+    const now = element.textContent ?? "";
+    if (now === typed) {
+      return;
+    }
+    rendered = now;
+    if (!edited) {
+      // Nothing typed yet: follow the update, minus its stega.
+      typed = stegaClean(now);
+      show(typed);
+      return;
+    }
+    if (composing) {
+      return;
+    }
+    show(typed);
+    placeCaret(element, caret);
+  };
+
+  // May run before the keystroke's `input` event, so `beforeinput` is the
+  // marker that says "the editor did this". Any other change is a render.
+  const observer = new MutationObserver(() => {
+    if (typing) {
+      typing = false;
+      keepOwnNode();
+      return;
+    }
+    onRender();
+  });
+
+  const onBeforeInput = () => {
+    typing = true;
+    // Backspace at the start changes nothing, so no mutation clears the flag,
+    // and a stale one lets the next render through over the typed text.
+    setTimeout(() => {
+      typing = false;
+    });
+  };
+
+  // `execCommand` fires no `beforeinput`, but its `input` lands before the
+  // observer runs, so re-homing the text here covers pastes too.
+  const onInput = () => {
+    typing = false;
+    edited = true;
+    typed = element.textContent ?? "";
+    caret = caretOffset(element) ?? caret;
+    keepOwnNode();
+  };
+
+  const onSelectionChange = () => {
+    caret = caretOffset(element) ?? caret;
+  };
+
+  const onCompositionStart = () => {
+    composing = true;
+  };
+  const onCompositionEnd = () => {
+    composing = false;
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    // Enter while composing picks an IME candidate; it does not end the edit.
+    if (event.isComposing) {
+      return;
+    }
+    // A string holds one line and a span cannot split a paragraph, so Enter
+    // saves rather than opening a line that could never be stored.
+    if (event.key === "Enter") {
+      event.preventDefault();
+      element.blur();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelled = true;
+      element.blur();
+    }
+  };
+
+  const onPaste = (event: ClipboardEvent) => {
+    event.preventDefault();
+    // One line: a pasted newline becomes a line break `textContent` drops,
+    // gluing the words either side of it together.
+    const text = (event.clipboardData?.getData("text/plain") ?? "").replace(
+      /\s+/g,
+      " "
+    );
+    // `execCommand` is deprecated but the only one-liner that inserts at the
+    // caret with undo intact; swap for a Range insert if a browser drops it.
+    element.ownerDocument.execCommand("insertText", false, text);
+  };
+
+  const onBlur = () => {
+    observer.disconnect();
+    element.removeEventListener("beforeinput", onBeforeInput);
+    element.removeEventListener("input", onInput);
+    element.removeEventListener("keydown", onKeyDown);
+    element.removeEventListener("paste", onPaste);
+    element.removeEventListener("compositionstart", onCompositionStart);
+    element.removeEventListener("compositionend", onCompositionEnd);
+    element.ownerDocument.removeEventListener(
+      "selectionchange",
+      onSelectionChange
+    );
+    element.removeAttribute("contenteditable");
+    element.removeAttribute("spellcheck");
+    if (aborted) {
+      return;
+    }
+
+    const text = stegaClean(typed);
+    // Cancelled, unchanged, or emptied. A cleared field unmounts its element
+    // and fails validation, so empty counts as a cancel.
+    if (cancelled || !text.trim() || text === stegaClean(rendered)) {
+      show(rendered);
+      return;
+    }
+    show(text);
+    save(text).catch(() => show(rendered));
+  };
+
+  show(typed);
+  // `plaintext-only` keeps Cmd+B/I and rich drops from adding formatting the
+  // save could never keep.
+  element.contentEditable = "plaintext-only";
+  element.spellcheck = false;
+  element.addEventListener("beforeinput", onBeforeInput);
+  element.addEventListener("input", onInput);
+  element.addEventListener("keydown", onKeyDown);
+  element.addEventListener("paste", onPaste);
+  element.addEventListener("compositionstart", onCompositionStart);
+  element.addEventListener("compositionend", onCompositionEnd);
+  element.addEventListener("blur", onBlur, { once: true });
+  element.ownerDocument.addEventListener("selectionchange", onSelectionChange);
+  observer.observe(element, {
+    characterData: true,
+    childList: true,
+    subtree: true,
+  });
+
+  element.focus();
+  placeCaret(element, caret);
+}
+
+/**
+ * Double-click to type into a string or Portable Text span; renders nothing.
+ * Writes to the overlay node's own `id` and `path`, as Sanity's overlay
+ * examples do, so text from a referenced document saves to that document.
+ * Only mounted in Presentation: custom components wait for the optimistic
+ * actor, which only the Presentation connection sets up.
+ */
+export const InlineText: OverlayComponent = ({ element, node }) => {
+  const { getDocument } = useDocuments();
+  const { id, path } = node;
+
+  useEffect(() => {
+    // `ElementNode` is `HTMLElement | SVGElement`; only the former is typeable.
+    if (!(element instanceof HTMLElement)) {
+      return;
+    }
+    const target = element;
+
+    const onDoubleClick = (event: Event) => {
+      // A session already running: the overlay component remounts whenever the
+      // pointer re-enters, so this listener can be re-added mid-edit.
+      if (target.isContentEditable) {
+        return;
+      }
+      event.preventDefault();
+
+      startEditing(target, (text) =>
+        // Inside the chain, so a throwing `getDocument` (a document the overlay
+        // is not tracking) fails like a rejected write instead of escaping.
+        Promise.resolve()
+          .then(() => getDocument(id).patch([at(path, set(text))]))
+          .catch((error: unknown) => {
+            logger.error(`patch failed for ${path}`, error);
+            throw error;
+          })
+      );
+    };
+
+    target.addEventListener("dblclick", onDoubleClick);
+    return () => target.removeEventListener("dblclick", onDoubleClick);
+  }, [element, id, path, getDocument]);
+
+  return null;
+};

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -337,12 +337,15 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
     }
     const target = element;
     let pendingClick: ReturnType<typeof setTimeout> | undefined;
+    const cancelPending = () => {
+      clearTimeout(pendingClick);
+      pendingClick = undefined;
+    };
 
     // A synthetic click passes the capture below and reaches the overlay,
     // which opens this field in the Studio.
     const openInStudio = () => {
-      clearTimeout(pendingClick);
-      pendingClick = undefined;
+      cancelPending();
       target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     };
 
@@ -355,7 +358,7 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
     };
 
     const onDoubleClick = (event: Event) => {
-      clearTimeout(pendingClick);
+      cancelPending();
       // The overlay remounts this on every hover, so a session may be running.
       if (target.isContentEditable) {
         return;
@@ -388,7 +391,7 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
         return;
       }
       event.stopPropagation();
-      clearTimeout(pendingClick);
+      cancelPending();
       if (!target.isContentEditable) {
         pendingClick = setTimeout(openInStudio, DOUBLE_CLICK_MS);
       }
@@ -404,7 +407,7 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
       signal,
     });
     return () => {
-      clearTimeout(pendingClick);
+      cancelPending();
       listeners.abort();
     };
   }, [element, id, path, getDocument]);

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -1,32 +1,28 @@
 "use client";
 
 import { at, set } from "@sanity/mutate";
-import type { OverlayComponent } from "@sanity/visual-editing/react";
-import { useDocuments } from "@sanity/visual-editing/react";
+import {
+  type OverlayComponent,
+  useDocuments,
+} from "@sanity/visual-editing/react";
 import { Logger } from "@workspace/logger";
 import { stegaClean } from "next-sanity";
 import { useEffect } from "react";
 
 const logger = new Logger("inline-text");
 
-/** Set by a block on an element that renders one plain string field. */
 const EDIT_ATTR = "data-inline-edit";
 
-/** A Portable Text span's text, `…[_key=="b"].children[_key=="s"].text`: its
- * own plain string, so its words are typeable. Marks, links and paragraph
- * breaks stay in the Studio form. */
+/** How long the Studio can take to open the field and focus its input. */
+const RECLAIM_MS = 5000;
+
+/** A Portable Text span's text: its own plain string, so its words are typeable. */
 const SPAN_TEXT = /\.children\[_key=="[^"]+"\]\.text$/;
 
 /**
- * Whether double-click typing arms here. Opt-in, because the resolver also
- * sees every nav link, button label and badge:
- * - a flagged `string` element (not `text`: it can hold several lines, and
- *   Enter saves), or
- * - a Portable Text span whose element holds only its text: a one-span
- *   paragraph, or the bold/italic run inside one. A mixed paragraph renders
- *   its plain runs straight into the `<p>`, so those have no element to type in.
- * Never inside a link or button: with the overlay toggled off its click
- * capture is gone, so a click to move the caret would follow the link.
+ * Opt-in: a flagged `string` element (not `text`, which can hold several
+ * lines), or a Portable Text span whose element holds only its text. Never
+ * inside a link or button, where a caret click could follow the link.
  */
 export function isInlineEditable(
   element: Element,
@@ -43,10 +39,8 @@ export function isInlineEditable(
     : SPAN_TEXT.test(path);
 }
 
-/** Caret position as a character offset, so it survives the text being
- * rewritten under it. */
 function caretOffset(element: HTMLElement): number | null {
-  const selection = element.ownerDocument.defaultView?.getSelection();
+  const selection = element.ownerDocument.getSelection();
   if (!selection?.rangeCount || !element.contains(selection.anchorNode)) {
     return null;
   }
@@ -67,27 +61,15 @@ function placeCaret(element: HTMLElement, offset: number) {
     range.selectNodeContents(element);
     range.collapse(false);
   }
-  const selection = element.ownerDocument.defaultView?.getSelection();
+  const selection = element.ownerDocument.getSelection();
   selection?.removeAllRanges();
   selection?.addRange(range);
 }
 
 /**
- * Turns one element into a text field until blur, then saves once. Imperative
- * and detached from React: the overlay component unmounts when the pointer
- * leaves, so an effect cleanup would end the session mid-sentence.
- *
- * - Strip stega first: it trails the text invisibly, so Backspace deleted
- *   nothing visible for dozens of presses.
- * - Save only on blur: each save re-renders, and a render overwrites the
- *   screen, so typed characters vanished and came back.
- * - A render landing mid-edit (the last save's refresh, a Studio edit) gets
- *   the typed text put back over it; Escape shows the newest render.
- * - Rewrite React's text node in place, never swap it: Portable Text spans are
- *   nodes React holds on to, and it would later update or remove a stray one.
- * - No save, or a failed one: restore React's text with its stega, so the page
- *   never shows a value the document lacks and the overlay finds it again.
- * - React removes its node mid-edit: end without saving or touching its DOM.
+ * Makes `element` editable until blur, then saves once. Saving mid-edit would
+ * re-render the text under the caret. Imperative, because the overlay
+ * component unmounts as soon as the pointer leaves.
  */
 function startEditing(
   element: HTMLElement,
@@ -97,40 +79,69 @@ function startEditing(
   if (!(own instanceof Text)) {
     return;
   }
+  const ownIsOnlyChild = () =>
+    element.firstChild === own && element.childNodes.length === 1;
+  // Rewrite React's node in place: Portable Text spans are nodes React keeps
+  // and later updates or removes.
   const show = (text: string) => {
-    own.nodeValue = text;
-    // Typing can leave the browser's own nodes in place of React's.
-    if (element.firstChild !== own || element.childNodes.length > 1) {
+    own.data = text;
+    if (!ownIsOnlyChild()) {
       element.replaceChildren(own);
     }
   };
 
-  // What React last wrote, stega included.
-  let rendered = own.nodeValue ?? "";
+  // Last text React rendered, stega included.
+  let rendered = own.data;
+  // Stega trails the text invisibly; left in, Backspace deletes nothing visible.
   let typed = stegaClean(rendered);
   let caret = typed.length;
   let edited = false;
   let typing = false;
   let composing = false;
+  let missedRender = false;
+  // Set once a paste or re-home replaces nodes the undo history points at.
+  let staleUndo = false;
   let cancelled = false;
   let aborted = false;
+  let reclaimed = false;
+  const startedAt = Date.now();
+  const listeners = new AbortController();
 
-  // The browser may swap React's node while editing (a paste over a selection
-  // does); put it back, so React's later updates land on a node still in the
-  // page and the removal check below never mistakes the swap for React's.
+  // The Studio focuses its input once the field's pane opens, even mid-typing;
+  // take focus back once.
+  const reclaimFocus = () => {
+    if (
+      reclaimed ||
+      Date.now() - startedAt > RECLAIM_MS ||
+      element.ownerDocument.hasFocus()
+    ) {
+      return false;
+    }
+    reclaimed = true;
+    element.focus();
+    placeCaret(element, caret);
+    return element.ownerDocument.hasFocus();
+  };
+
+  // The browser can swap React's node, as a paste over a selection does.
   const keepOwnNode = () => {
-    if (element.firstChild === own && element.childNodes.length === 1) {
+    if (ownIsOnlyChild()) {
       return;
     }
+    staleUndo = true;
     const offset = caretOffset(element) ?? caret;
     typed = element.textContent ?? "";
     show(typed);
     placeCaret(element, offset);
   };
 
+  const restoreTyped = () => {
+    show(typed);
+    placeCaret(element, caret);
+  };
+
   const onRender = () => {
-    // React removed its node (span restructured, field cleared): the DOM is
-    // React's now, and the path may no longer exist.
+    // React removed its node: the DOM is React's again and the path may be gone.
     if (!element.contains(own)) {
       aborted = true;
       element.blur();
@@ -142,20 +153,19 @@ function startEditing(
     }
     rendered = now;
     if (!edited) {
-      // Nothing typed yet: follow the update, minus its stega.
       typed = stegaClean(now);
       show(typed);
       return;
     }
+    // Rewriting mid-composition breaks the IME; restore once it ends.
     if (composing) {
+      missedRender = true;
       return;
     }
-    show(typed);
-    placeCaret(element, caret);
+    restoreTyped();
   };
 
-  // May run before the keystroke's `input` event, so `beforeinput` is the
-  // marker that says "the editor did this". Any other change is a render.
+  // `beforeinput` marks a change as typed; any other change is a render.
   const observer = new MutationObserver(() => {
     if (typing) {
       typing = false;
@@ -165,26 +175,40 @@ function startEditing(
     onRender();
   });
 
-  const onBeforeInput = () => {
+  const onBeforeInput = (event: InputEvent) => {
+    // Drops skip the paste cleanup, and stale undo would edit a detached node.
+    if (
+      event.inputType === "insertFromDrop" ||
+      (staleUndo && event.inputType.startsWith("history"))
+    ) {
+      event.preventDefault();
+      return;
+    }
     typing = true;
-    // Backspace at the start changes nothing, so no mutation clears the flag,
-    // and a stale one lets the next render through over the typed text.
+    // A keystroke that changes nothing leaves no mutation to clear the flag.
     setTimeout(() => {
       typing = false;
     });
   };
 
-  // `execCommand` fires no `beforeinput`, but its `input` lands before the
-  // observer runs, so re-homing the text here covers pastes too.
   const onInput = () => {
     typing = false;
     edited = true;
+    // Keep the text from before a mid-composition render until it's restored.
+    if (missedRender) {
+      return;
+    }
     typed = element.textContent ?? "";
     caret = caretOffset(element) ?? caret;
     keepOwnNode();
   };
 
   const onSelectionChange = () => {
+    // Firefox fires no blur when a focused element is removed.
+    if (!element.isConnected) {
+      end();
+      return;
+    }
     caret = caretOffset(element) ?? caret;
   };
 
@@ -193,15 +217,18 @@ function startEditing(
   };
   const onCompositionEnd = () => {
     composing = false;
+    if (missedRender) {
+      missedRender = false;
+      restoreTyped();
+    }
   };
 
   const onKeyDown = (event: KeyboardEvent) => {
-    // Enter while composing picks an IME candidate; it does not end the edit.
+    // Enter while composing picks an IME candidate.
     if (event.isComposing) {
       return;
     }
-    // A string holds one line and a span cannot split a paragraph, so Enter
-    // saves rather than opening a line that could never be stored.
+    // The text is one line, so Enter saves.
     if (event.key === "Enter") {
       event.preventDefault();
       element.blur();
@@ -216,59 +243,76 @@ function startEditing(
 
   const onPaste = (event: ClipboardEvent) => {
     event.preventDefault();
-    // One line: a pasted newline becomes a line break `textContent` drops,
-    // gluing the words either side of it together.
-    const text = (event.clipboardData?.getData("text/plain") ?? "").replace(
-      /\s+/g,
-      " "
+    const selection = element.ownerDocument.getSelection();
+    if (!selection?.rangeCount) {
+      return;
+    }
+    // Newlines to spaces: `textContent` drops line breaks and glues the words.
+    const pasted = element.ownerDocument.createTextNode(
+      (event.clipboardData?.getData("text/plain") ?? "").replace(/\s+/g, " ")
     );
-    // `execCommand` is deprecated but the only one-liner that inserts at the
-    // caret with undo intact; swap for a Range insert if a browser drops it.
-    element.ownerDocument.execCommand("insertText", false, text);
+    const range = selection.getRangeAt(0);
+    range.deleteContents();
+    range.insertNode(pasted);
+    range.setStartAfter(pasted);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    staleUndo = true;
+    // A DOM insert fires no `input` event.
+    onInput();
+  };
+
+  const end = () => {
+    listeners.abort();
+    observer.disconnect();
+    element.removeAttribute("contenteditable");
+    element.removeAttribute("spellcheck");
+    element.style.removeProperty("outline");
   };
 
   const onBlur = () => {
-    observer.disconnect();
-    element.removeEventListener("beforeinput", onBeforeInput);
-    element.removeEventListener("input", onInput);
-    element.removeEventListener("keydown", onKeyDown);
-    element.removeEventListener("paste", onPaste);
-    element.removeEventListener("compositionstart", onCompositionStart);
-    element.removeEventListener("compositionend", onCompositionEnd);
-    element.ownerDocument.removeEventListener(
-      "selectionchange",
-      onSelectionChange
-    );
-    element.removeAttribute("contenteditable");
-    element.removeAttribute("spellcheck");
-    if (aborted) {
+    if (reclaimFocus()) {
       return;
     }
-
+    end();
+    // A removed element (block deleted, field cleared elsewhere) never saves.
+    if (aborted || !element.isConnected) {
+      return;
+    }
     const text = stegaClean(typed);
-    // Cancelled, unchanged, or emptied. A cleared field unmounts its element
-    // and fails validation, so empty counts as a cancel.
+    // Empty counts as cancel: a cleared field unmounts its element and fails
+    // validation.
     if (cancelled || !text.trim() || text === stegaClean(rendered)) {
       show(rendered);
       return;
     }
     show(text);
-    save(text).catch(() => show(rendered));
+    // A rejected patch puts the rendered text back, unless React re-rendered.
+    save(text).catch(() => {
+      if (element.contains(own) && own.data === text) {
+        own.data = rendered;
+      }
+    });
   };
 
-  show(typed);
-  // `plaintext-only` keeps Cmd+B/I and rich drops from adding formatting the
-  // save could never keep.
+  // Plain text only: Cmd+B/I and rich drops would add formatting no save keeps.
   element.contentEditable = "plaintext-only";
   element.spellcheck = false;
-  element.addEventListener("beforeinput", onBeforeInput);
-  element.addEventListener("input", onInput);
-  element.addEventListener("keydown", onKeyDown);
-  element.addEventListener("paste", onPaste);
-  element.addEventListener("compositionstart", onCompositionStart);
-  element.addEventListener("compositionend", onCompositionEnd);
-  element.addEventListener("blur", onBlur, { once: true });
-  element.ownerDocument.addEventListener("selectionchange", onSelectionChange);
+  // The site's global `:focus-visible` ring would outline the text mid-edit.
+  element.style.outline = "none";
+  show(typed);
+  const { signal } = listeners;
+  element.addEventListener("beforeinput", onBeforeInput, { signal });
+  element.addEventListener("input", onInput, { signal });
+  element.addEventListener("keydown", onKeyDown, { signal });
+  element.addEventListener("paste", onPaste, { signal });
+  element.addEventListener("compositionstart", onCompositionStart, { signal });
+  element.addEventListener("compositionend", onCompositionEnd, { signal });
+  element.addEventListener("blur", onBlur, { signal });
+  element.ownerDocument.addEventListener("selectionchange", onSelectionChange, {
+    signal,
+  });
   observer.observe(element, {
     characterData: true,
     childList: true,
@@ -280,34 +324,28 @@ function startEditing(
 }
 
 /**
- * Double-click to type into a string or Portable Text span; renders nothing.
- * Writes to the overlay node's own `id` and `path`, as Sanity's overlay
- * examples do, so text from a referenced document saves to that document.
- * Only mounted in Presentation: custom components wait for the optimistic
- * actor, which only the Presentation connection sets up.
+ * Double-click to type into the text; renders nothing. Writes to the overlay
+ * node's own `id` and `path`, so text from a referenced document saves there.
  */
 export const InlineText: OverlayComponent = ({ element, node }) => {
   const { getDocument } = useDocuments();
   const { id, path } = node;
 
   useEffect(() => {
-    // `ElementNode` is `HTMLElement | SVGElement`; only the former is typeable.
     if (!(element instanceof HTMLElement)) {
       return;
     }
     const target = element;
 
     const onDoubleClick = (event: Event) => {
-      // A session already running: the overlay component remounts whenever the
-      // pointer re-enters, so this listener can be re-added mid-edit.
+      // The overlay remounts this on every hover, so a session may be running.
       if (target.isContentEditable) {
         return;
       }
       event.preventDefault();
 
       startEditing(target, (text) =>
-        // Inside the chain, so a throwing `getDocument` (a document the overlay
-        // is not tracking) fails like a rejected write instead of escaping.
+        // In the chain, because `getDocument` can throw for an untracked id.
         Promise.resolve()
           .then(() => getDocument(id).patch([at(path, set(text))]))
           .catch((error: unknown) => {
@@ -317,8 +355,27 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
       );
     };
 
-    target.addEventListener("dblclick", onDoubleClick);
-    return () => target.removeEventListener("dblclick", onDoubleClick);
+    // Each click the overlay sees opens this field in the Studio, which takes
+    // focus. Hide the double-click's second click and caret clicks mid-edit.
+    const onClickCapture = (event: MouseEvent) => {
+      if (
+        (event.detail > 1 || target.isContentEditable) &&
+        event.target instanceof Node &&
+        target.contains(event.target)
+      ) {
+        event.stopPropagation();
+      }
+    };
+
+    const listeners = new AbortController();
+    const { signal } = listeners;
+    target.addEventListener("dblclick", onDoubleClick, { signal });
+    target.ownerDocument.defaultView?.addEventListener(
+      "click",
+      onClickCapture,
+      { capture: true, signal }
+    );
+    return () => listeners.abort();
   }, [element, id, path, getDocument]);
 
   return null;

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -84,7 +84,7 @@ function startEditing(
   // Rewrite React's node in place: Portable Text spans are nodes React keeps
   // and later updates or removes.
   const show = (text: string) => {
-    own.data = text;
+    own.textContent = text;
     if (!ownIsOnlyChild()) {
       element.replaceChildren(own);
     }
@@ -99,6 +99,8 @@ function startEditing(
   let typing = false;
   let composing = false;
   let missedRender = false;
+  // Text and caret as the IME started, to rebuild from after a missed render.
+  let composeFrom = { text: typed, at: caret };
   // Set once a paste or re-home replaces nodes the undo history points at.
   let staleUndo = false;
   let cancelled = false;
@@ -107,8 +109,8 @@ function startEditing(
   const startedAt = Date.now();
   const listeners = new AbortController();
 
-  // The Studio focuses its input once the field's pane opens, even mid-typing;
-  // take focus back once.
+  // The Studio focuses its input once the field's pane opens, even mid-typing.
+  // Refocus after the blur finishes dispatching, or it is ignored.
   const reclaimFocus = () => {
     if (
       reclaimed ||
@@ -118,9 +120,16 @@ function startEditing(
       return false;
     }
     reclaimed = true;
-    element.focus();
-    placeCaret(element, caret);
-    return element.ownerDocument.hasFocus();
+    setTimeout(() => {
+      element.ownerDocument.defaultView?.focus();
+      element.focus();
+      if (element.ownerDocument.hasFocus()) {
+        placeCaret(element, caret);
+      } else {
+        finish();
+      }
+    });
+    return true;
   };
 
   // The browser can swap React's node, as a paste over a selection does.
@@ -194,7 +203,7 @@ function startEditing(
   const onInput = () => {
     typing = false;
     edited = true;
-    // Keep the text from before a mid-composition render until it's restored.
+    // After a mid-composition render the DOM is stale; compositionend rebuilds.
     if (missedRender) {
       return;
     }
@@ -214,13 +223,24 @@ function startEditing(
 
   const onCompositionStart = () => {
     composing = true;
+    // A composition over a selection replaces it; `caret` is the selection end.
+    const selected = element.ownerDocument.getSelection()?.toString() ?? "";
+    const start = Math.max(0, caret - selected.length);
+    composeFrom = {
+      text: typed.slice(0, start) + typed.slice(caret),
+      at: start,
+    };
   };
-  const onCompositionEnd = () => {
+  const onCompositionEnd = (event: CompositionEvent) => {
     composing = false;
-    if (missedRender) {
-      missedRender = false;
-      restoreTyped();
+    if (!missedRender) {
+      return;
     }
+    missedRender = false;
+    const { text, at } = composeFrom;
+    typed = text.slice(0, at) + event.data + text.slice(at);
+    caret = at + event.data.length;
+    restoreTyped();
   };
 
   const onKeyDown = (event: KeyboardEvent) => {
@@ -242,6 +262,11 @@ function startEditing(
   };
 
   const onPaste = (event: ClipboardEvent) => {
+    const text = event.clipboardData?.getData("text/plain") ?? "";
+    // A one-line paste goes through the browser, so undo still covers it.
+    if (!/[\r\n\t]/.test(text)) {
+      return;
+    }
     event.preventDefault();
     const selection = element.ownerDocument.getSelection();
     if (!selection?.rangeCount) {
@@ -249,7 +274,7 @@ function startEditing(
     }
     // Newlines to spaces: `textContent` drops line breaks and glues the words.
     const pasted = element.ownerDocument.createTextNode(
-      (event.clipboardData?.getData("text/plain") ?? "").replace(/\s+/g, " ")
+      text.replace(/\s+/g, " ")
     );
     const range = selection.getRangeAt(0);
     range.deleteContents();
@@ -272,9 +297,12 @@ function startEditing(
   };
 
   const onBlur = () => {
-    if (reclaimFocus()) {
-      return;
+    if (!reclaimFocus()) {
+      finish();
     }
+  };
+
+  const finish = () => {
     end();
     // A removed element (block deleted, field cleared elsewhere) never saves.
     if (aborted || !element.isConnected) {
@@ -291,7 +319,7 @@ function startEditing(
     // A rejected patch puts the rendered text back, unless React re-rendered.
     save(text).catch(() => {
       if (element.contains(own) && own.data === text) {
-        own.data = rendered;
+        own.textContent = rendered;
       }
     });
   };

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -13,8 +13,9 @@ const logger = new Logger("inline-text");
 
 const EDIT_ATTR = "data-inline-edit";
 
-/** Longest gap between the two clicks of a double-click. */
-const DOUBLE_CLICK_MS = 300;
+/** The macOS, Windows and Chrome default; a slower system setting replays the
+ * first click early, ending the edit unsaved. The next double-click then works. */
+const DOUBLE_CLICK_MS = 500;
 
 /** A Portable Text span's text: its own plain string, so its words are typeable. */
 const SPAN_TEXT = /\.children\[_key=="[^"]+"\]\.text$/;
@@ -339,8 +340,19 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
 
     // A synthetic click passes the capture below and reaches the overlay,
     // which opens this field in the Studio.
-    const openInStudio = () =>
+    const openInStudio = () => {
+      clearTimeout(pendingClick);
+      pendingClick = undefined;
       target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    };
+
+    // The overlay ignores clicks on an unhovered element, so replay before its
+    // own mouseleave handler runs.
+    const onLeaveCapture = (event: MouseEvent) => {
+      if (event.target === target && pendingClick !== undefined) {
+        openInStudio();
+      }
+    };
 
     const onDoubleClick = (event: Event) => {
       clearTimeout(pendingClick);
@@ -385,11 +397,12 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
     const listeners = new AbortController();
     const { signal } = listeners;
     target.addEventListener("dblclick", onDoubleClick, { signal });
-    target.ownerDocument.defaultView?.addEventListener(
-      "click",
-      onClickCapture,
-      { capture: true, signal }
-    );
+    const view = target.ownerDocument.defaultView;
+    view?.addEventListener("click", onClickCapture, { capture: true, signal });
+    view?.addEventListener("mouseleave", onLeaveCapture, {
+      capture: true,
+      signal,
+    });
     return () => {
       clearTimeout(pendingClick);
       listeners.abort();

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -21,23 +21,20 @@ const DOUBLE_CLICK_MS = 500;
 const SPAN_TEXT = /\.children\[_key=="[^"]+"\]\.text$/;
 
 /**
- * Opt-in: a flagged `string` element (not `text`, which can hold several
- * lines), or a Portable Text span whose element holds only its text. Never
- * inside a link or button, where a caret click could follow the link.
+ * Opt-in: a flagged element, or a Portable Text span whose element holds only
+ * its text. Never inside a click target, whose handler the click capture would
+ * swallow. Only flag `string` fields: a multi-line `text` field looks the same.
  */
-export function isInlineEditable(
-  element: Element,
-  path: string,
-  type?: string
-) {
+export function isInlineEditable(element: Element, path: string) {
   const onlyText =
     element.childNodes.length === 1 && element.firstChild instanceof Text;
-  if (!onlyText || element.closest("a, button")) {
+  if (
+    !onlyText ||
+    element.closest("a, button, summary, label, [role=button]")
+  ) {
     return false;
   }
-  return element.hasAttribute(EDIT_ATTR)
-    ? type === "string"
-    : SPAN_TEXT.test(path);
+  return element.hasAttribute(EDIT_ATTR) || SPAN_TEXT.test(path);
 }
 
 function caretOffset(element: HTMLElement): number | null {
@@ -140,7 +137,8 @@ function startEditing(
     rendered = now;
     if (!edited) {
       typed = stegaClean(now);
-      show(typed);
+      // Rewriting the node collapses a live range to offset 0.
+      restoreTyped();
       return;
     }
     // Rewriting mid-composition breaks the IME; restore once it ends.
@@ -294,7 +292,7 @@ function startEditing(
       return;
     }
     show(text);
-    // A rejected patch puts the rendered text back, unless React re-rendered.
+    // Only a local failure rejects; the Studio's own write is fire-and-forget.
     save(text).catch(() => {
       if (element.contains(own) && own.data === text) {
         own.textContent = rendered;
@@ -349,16 +347,24 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
     };
 
     // A synthetic click passes the capture below and reaches the overlay,
-    // which opens this field in the Studio.
+    // which opens this field in the Studio. The overlay only honours a click
+    // on its hovered element, so hover it for the duration of the click.
     const openInStudio = () => {
       cancelPending();
-      target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      for (const type of ["mouseenter", "click", "mouseleave"]) {
+        target.dispatchEvent(
+          new MouseEvent(type, { bubbles: type === "click" })
+        );
+      }
     };
 
-    // The overlay ignores clicks on an unhovered element, so replay before its
-    // own mouseleave handler runs.
+    // The overlay unmounts this component on leave, taking the timer with it.
     const onLeaveCapture = (event: MouseEvent) => {
-      if (event.target === target && pendingClick !== undefined) {
+      if (
+        event.isTrusted &&
+        event.target === target &&
+        pendingClick !== undefined
+      ) {
         openInStudio();
       }
     };
@@ -406,6 +412,10 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
     const listeners = new AbortController();
     const { signal } = listeners;
     target.addEventListener("dblclick", onDoubleClick, { signal });
+    // Before the overlay's schema handshake mounts this, a double-click falls
+    // through to stock click-to-edit; the text cursor marks it armed.
+    const cursor = target.style.cursor;
+    target.style.cursor = "text";
     const view = target.ownerDocument.defaultView;
     view?.addEventListener("click", onClickCapture, { capture: true, signal });
     view?.addEventListener("mouseleave", onLeaveCapture, {
@@ -415,6 +425,7 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
     return () => {
       cancelPending();
       listeners.abort();
+      target.style.cursor = cursor;
     };
   }, [element, id, path, getDocument]);
 

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -101,8 +101,8 @@ function startEditing(
   let typing = false;
   let composing = false;
   let missedRender = false;
-  // Text and caret as the IME started, to rebuild from after a missed render.
-  let composeFrom = { text: typed, at: caret };
+  // Text and selection as the IME started, to rebuild from after a missed render.
+  let composeFrom = { text: typed, start: caret, end: caret };
   // Set once a paste or re-home replaces nodes the undo history points at.
   let staleUndo = false;
   let cancelled = false;
@@ -200,12 +200,12 @@ function startEditing(
 
   const onCompositionStart = () => {
     composing = true;
-    // A composition over a selection replaces it; `caret` is the selection end.
+    // `caret` is the selection end; a composition replaces the selection.
     const selected = element.ownerDocument.getSelection()?.toString() ?? "";
-    const start = Math.max(0, caret - selected.length);
     composeFrom = {
-      text: typed.slice(0, start) + typed.slice(caret),
-      at: start,
+      text: typed,
+      start: Math.max(0, caret - selected.length),
+      end: caret,
     };
   };
   const onCompositionEnd = (event: CompositionEvent) => {
@@ -214,9 +214,15 @@ function startEditing(
       return;
     }
     missedRender = false;
-    const { text, at } = composeFrom;
-    typed = text.slice(0, at) + event.data + text.slice(at);
-    caret = at + event.data.length;
+    const { text, start, end } = composeFrom;
+    // Empty data is a cancelled composition, which browsers undo in full.
+    if (!event.data) {
+      typed = text;
+      caret = end;
+    } else {
+      typed = text.slice(0, start) + event.data + text.slice(end);
+      caret = start + event.data.length;
+    }
     restoreTyped();
   };
 

--- a/apps/web/src/components/inline-text.tsx
+++ b/apps/web/src/components/inline-text.tsx
@@ -13,8 +13,8 @@ const logger = new Logger("inline-text");
 
 const EDIT_ATTR = "data-inline-edit";
 
-/** How long the Studio can take to open the field and focus its input. */
-const RECLAIM_MS = 5000;
+/** Longest gap between the two clicks of a double-click. */
+const DOUBLE_CLICK_MS = 300;
 
 /** A Portable Text span's text: its own plain string, so its words are typeable. */
 const SPAN_TEXT = /\.children\[_key=="[^"]+"\]\.text$/;
@@ -73,7 +73,8 @@ function placeCaret(element: HTMLElement, offset: number) {
  */
 function startEditing(
   element: HTMLElement,
-  save: (text: string) => Promise<unknown>
+  save: (text: string) => Promise<unknown>,
+  onEnter: () => void
 ) {
   const own = element.firstChild;
   if (!(own instanceof Text)) {
@@ -105,32 +106,7 @@ function startEditing(
   let staleUndo = false;
   let cancelled = false;
   let aborted = false;
-  let reclaimed = false;
-  const startedAt = Date.now();
   const listeners = new AbortController();
-
-  // The Studio focuses its input once the field's pane opens, even mid-typing.
-  // Refocus after the blur finishes dispatching, or it is ignored.
-  const reclaimFocus = () => {
-    if (
-      reclaimed ||
-      Date.now() - startedAt > RECLAIM_MS ||
-      element.ownerDocument.hasFocus()
-    ) {
-      return false;
-    }
-    reclaimed = true;
-    setTimeout(() => {
-      element.ownerDocument.defaultView?.focus();
-      element.focus();
-      if (element.ownerDocument.hasFocus()) {
-        placeCaret(element, caret);
-      } else {
-        finish();
-      }
-    });
-    return true;
-  };
 
   // The browser can swap React's node, as a paste over a selection does.
   const keepOwnNode = () => {
@@ -252,6 +228,7 @@ function startEditing(
     if (event.key === "Enter") {
       event.preventDefault();
       element.blur();
+      onEnter();
       return;
     }
     if (event.key === "Escape") {
@@ -297,12 +274,6 @@ function startEditing(
   };
 
   const onBlur = () => {
-    if (!reclaimFocus()) {
-      finish();
-    }
-  };
-
-  const finish = () => {
     end();
     // A removed element (block deleted, field cleared elsewhere) never saves.
     if (aborted || !element.isConnected) {
@@ -364,34 +335,50 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
       return;
     }
     const target = element;
+    let pendingClick: ReturnType<typeof setTimeout> | undefined;
+
+    // A synthetic click passes the capture below and reaches the overlay,
+    // which opens this field in the Studio.
+    const openInStudio = () =>
+      target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     const onDoubleClick = (event: Event) => {
+      clearTimeout(pendingClick);
       // The overlay remounts this on every hover, so a session may be running.
       if (target.isContentEditable) {
         return;
       }
       event.preventDefault();
 
-      startEditing(target, (text) =>
-        // In the chain, because `getDocument` can throw for an untracked id.
-        Promise.resolve()
-          .then(() => getDocument(id).patch([at(path, set(text))]))
-          .catch((error: unknown) => {
-            logger.error(`patch failed for ${path}`, error);
-            throw error;
-          })
+      startEditing(
+        target,
+        (text) =>
+          // In the chain, because `getDocument` can throw for an untracked id.
+          Promise.resolve()
+            .then(() => getDocument(id).patch([at(path, set(text))]))
+            .catch((error: unknown) => {
+              logger.error(`patch failed for ${path}`, error);
+              throw error;
+            }),
+        openInStudio
       );
     };
 
-    // Each click the overlay sees opens this field in the Studio, which takes
-    // focus. Hide the double-click's second click and caret clicks mid-edit.
+    // The Studio focuses its input when a click opens the field, which ends
+    // an edit mid-word. So no real click reaches the overlay: a single click
+    // is replayed once it is clearly not a double-click, and a double-click
+    // opens the field after Enter instead.
     const onClickCapture = (event: MouseEvent) => {
       if (
-        (event.detail > 1 || target.isContentEditable) &&
-        event.target instanceof Node &&
-        target.contains(event.target)
+        !event.isTrusted ||
+        !(event.target instanceof Node && target.contains(event.target))
       ) {
-        event.stopPropagation();
+        return;
+      }
+      event.stopPropagation();
+      clearTimeout(pendingClick);
+      if (!target.isContentEditable) {
+        pendingClick = setTimeout(openInStudio, DOUBLE_CLICK_MS);
       }
     };
 
@@ -403,7 +390,10 @@ export const InlineText: OverlayComponent = ({ element, node }) => {
       onClickCapture,
       { capture: true, signal }
     );
-    return () => listeners.abort();
+    return () => {
+      clearTimeout(pendingClick);
+      listeners.abort();
+    };
   }, [element, id, path, getDocument]);
 
   return null;

--- a/apps/web/src/components/overlay-components.tsx
+++ b/apps/web/src/components/overlay-components.tsx
@@ -7,5 +7,4 @@ import { InlineText, isInlineEditable } from "@/components/inline-text";
 export const overlayComponents: OverlayComponentResolver = ({
   element,
   node,
-  type,
-}) => (isInlineEditable(element, node.path, type) ? InlineText : undefined);
+}) => (isInlineEditable(element, node.path) ? InlineText : undefined);

--- a/apps/web/src/components/overlay-components.tsx
+++ b/apps/web/src/components/overlay-components.tsx
@@ -2,22 +2,10 @@ import type { OverlayComponentResolver } from "@sanity/visual-editing/react";
 
 import { InlineText, isInlineEditable } from "@/components/inline-text";
 
-/**
- * Arms double-click typing where `isInlineEditable` allows. Never under a
- * release: `useDocuments` always writes `drafts.<id>`, so the edit would miss
- * the version on screen. Published text is fine: a page with no draft renders
- * from it, and the first save creates the draft. A resolver, not a `plugins`
- * HUD, because only the resolver waits for the optimistic actor
- * `useDocuments` needs.
- */
+/** A resolver, not a `plugins` HUD: only the resolver waits for the
+ * optimistic actor `useDocuments` needs. */
 export const overlayComponents: OverlayComponentResolver = ({
   element,
   node,
   type,
-}) => {
-  const perspective = node.perspective ?? "drafts";
-  const editable =
-    (perspective === "drafts" || perspective === "published") &&
-    isInlineEditable(element, node.path, type);
-  return editable ? InlineText : undefined;
-};
+}) => (isInlineEditable(element, node.path, type) ? InlineText : undefined);

--- a/apps/web/src/components/overlay-components.tsx
+++ b/apps/web/src/components/overlay-components.tsx
@@ -1,0 +1,23 @@
+import type { OverlayComponentResolver } from "@sanity/visual-editing/react";
+
+import { InlineText, isInlineEditable } from "@/components/inline-text";
+
+/**
+ * Arms double-click typing where `isInlineEditable` allows. Never under a
+ * release: `useDocuments` always writes `drafts.<id>`, so the edit would miss
+ * the version on screen. Published text is fine: a page with no draft renders
+ * from it, and the first save creates the draft. A resolver, not a `plugins`
+ * HUD, because only the resolver waits for the optimistic actor
+ * `useDocuments` needs.
+ */
+export const overlayComponents: OverlayComponentResolver = ({
+  element,
+  node,
+  type,
+}) => {
+  const perspective = node.perspective ?? "drafts";
+  const editable =
+    (perspective === "drafts" || perspective === "published") &&
+    isInlineEditable(element, node.path, type);
+  return editable ? InlineText : undefined;
+};

--- a/apps/web/src/components/visual-editing-layer.tsx
+++ b/apps/web/src/components/visual-editing-layer.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { VisualEditing } from "next-sanity/visual-editing";
+
+import { overlayComponents } from "@/components/overlay-components";
+
+/**
+ * `<VisualEditing>` with this app's overlay components. Its own client
+ * component because the resolver is a function, which React refuses to pass
+ * from the server layout ("Functions cannot be passed directly to Client
+ * Components"). Rendered only in draft mode, so visitors never mount it.
+ */
+export function VisualEditingLayer() {
+  return <VisualEditing components={overlayComponents} />;
+}

--- a/apps/web/src/components/visual-editing-layer.tsx
+++ b/apps/web/src/components/visual-editing-layer.tsx
@@ -5,11 +5,15 @@ import { VisualEditing } from "next-sanity/visual-editing";
 import { overlayComponents } from "@/components/overlay-components";
 
 /**
- * `<VisualEditing>` with this app's overlay components. Its own client
- * component because the resolver is a function, which React refuses to pass
- * from the server layout ("Functions cannot be passed directly to Client
- * Components"). Rendered only in draft mode, so visitors never mount it.
+ * A client component because React won't pass the resolver function from the
+ * server layout ("Functions cannot be passed directly to Client Components").
+ * Inline editing only on drafts: saves always write `drafts.<id>`, which a
+ * published or release preview never shows.
  */
-export function VisualEditingLayer() {
-  return <VisualEditing components={overlayComponents} />;
+export function VisualEditingLayer({
+  inlineEditing,
+}: Readonly<{ inlineEditing: boolean }>) {
+  return (
+    <VisualEditing components={inlineEditing ? overlayComponents : undefined} />
+  );
 }

--- a/apps/web/tests/e2e/presentation-inline-edit.spec.ts
+++ b/apps/web/tests/e2e/presentation-inline-edit.spec.ts
@@ -1,0 +1,139 @@
+import type { Locator, Page } from "@playwright/test";
+
+import {
+  client,
+  deleteOwn,
+  expect,
+  LIVE_TIMEOUT,
+  prefix,
+  runId,
+  STUDIO_URL,
+  SYNC_TIMEOUT,
+  soft,
+  test,
+} from "./presentation-fixtures";
+
+const doc = {
+  id: `${prefix}inline`,
+  slug: `/${prefix}inline`,
+  title: `E2E inline ${runId}`,
+  heading: `E2E inline hero ${runId}`,
+};
+const draftId = `drafts.${doc.id}`;
+const saved = `${doc.heading} one two`;
+
+const heroTitle = () =>
+  client.fetch<string | null>(
+    `*[_id == $id][0].pageBuilder[_key == "hero"][0].title`,
+    { id: draftId }
+  );
+
+const boldSpan = () =>
+  client.fetch<{ text: string; marks: string[] } | null>(
+    `*[_id == $id][0].pageBuilder[_key == "hero"][0].richText[_key == "p"][0].children[_key == "b"][0]{text, marks}`,
+    { id: draftId }
+  );
+
+// The overlay arms the editor only while hovered, so a double-click can land
+// before it is armed.
+const armInlineEdit = async (target: Locator) => {
+  await expect(async () => {
+    await target.hover();
+    await target.dblclick();
+    await expect(target).toHaveAttribute("contenteditable", "plaintext-only", {
+      timeout: 1000,
+    });
+  }).toPass({ timeout: 30_000 });
+};
+
+// Without a field open in the Studio, so the double-click is what opens it.
+const openPreview = async (studio: Page) => {
+  await studio.goto(`${STUDIO_URL}/presentation?preview=${doc.slug}`);
+  return studio.frameLocator("iframe");
+};
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeAll(async () => {
+  await deleteOwn();
+  await client.create({
+    _id: draftId,
+    _type: "page",
+    title: doc.title,
+    slug: { _type: "slug", current: doc.slug },
+    pageBuilder: [
+      {
+        _type: "hero",
+        _key: "hero",
+        title: doc.heading,
+        richText: [
+          {
+            _type: "block",
+            _key: "p",
+            style: "normal",
+            markDefs: [],
+            children: [
+              { _type: "span", _key: "a", text: "Plain then ", marks: [] },
+              { _type: "span", _key: "b", text: "bold", marks: ["strong"] },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});
+
+test("double-click types into a heading and Enter saves it once", async ({
+  page: studio,
+}) => {
+  const preview = await openPreview(studio);
+  const heading = preview.getByRole("heading", {
+    level: 1,
+    name: doc.heading,
+  });
+  await expect(heading).toBeVisible({ timeout: LIVE_TIMEOUT });
+
+  await armInlineEdit(heading);
+  await studio.keyboard.type(" one");
+  // The Studio focuses its input once the field's pane loads; typing must stay
+  // on the page through that.
+  await studio.waitForTimeout(5000);
+  await studio.keyboard.type(" two");
+  await expect(heading).toHaveAttribute("contenteditable", "plaintext-only");
+  // Keystrokes that reached the Studio form would have autosaved by now.
+  expect(await heroTitle()).toBe(doc.heading);
+
+  await studio.keyboard.press("Enter");
+  await expect.poll(soft(heroTitle), { timeout: SYNC_TIMEOUT }).toBe(saved);
+  await expect(heading).not.toHaveAttribute("contenteditable");
+});
+
+test("Escape cancels without saving", async ({ page: studio }) => {
+  const preview = await openPreview(studio);
+  const heading = preview.getByRole("heading", { level: 1, name: saved });
+  await expect(heading).toBeVisible({ timeout: LIVE_TIMEOUT });
+
+  await armInlineEdit(heading);
+  await studio.keyboard.type(" discarded");
+  await studio.keyboard.press("Escape");
+  await expect(heading).not.toHaveAttribute("contenteditable");
+  await expect(heading).not.toContainText("discarded");
+  // Long enough for a stray save to land before asserting there was none.
+  await studio.waitForTimeout(2000);
+  expect(await heroTitle()).toBe(saved);
+});
+
+test("rich text: edits a bold run's words and keeps it bold", async ({
+  page: studio,
+}) => {
+  const preview = await openPreview(studio);
+  const bold = preview.locator("strong", { hasText: "bold" });
+  await expect(bold).toBeVisible({ timeout: LIVE_TIMEOUT });
+
+  await armInlineEdit(bold);
+  await studio.keyboard.type("er");
+  await studio.keyboard.press("Enter");
+  await expect
+    .poll(soft(boldSpan), { timeout: SYNC_TIMEOUT })
+    .toEqual({ text: "bolder", marks: ["strong"] });
+});

--- a/apps/web/tests/e2e/presentation-inline-edit.spec.ts
+++ b/apps/web/tests/e2e/presentation-inline-edit.spec.ts
@@ -95,8 +95,8 @@ test("double-click types into a heading and Enter saves it once", async ({
 
   await armInlineEdit(heading);
   await studio.keyboard.type(" one");
-  // The Studio focuses its input once the field's pane loads; typing must stay
-  // on the page through that.
+  // A click that reached the Studio would open the field and take focus. Give
+  // its pane time to have done so.
   await studio.waitForTimeout(5000);
   await studio.keyboard.type(" two");
   await expect(heading).toHaveAttribute("contenteditable", "plaintext-only");
@@ -106,6 +106,12 @@ test("double-click types into a heading and Enter saves it once", async ({
   await studio.keyboard.press("Enter");
   await expect.poll(soft(heroTitle), { timeout: SYNC_TIMEOUT }).toBe(saved);
   await expect(heading).not.toHaveAttribute("contenteditable");
+  // Enter is what opens the field in the Studio.
+  await expect(
+    studio
+      .getByTestId('field-pageBuilder[_key=="hero"].title')
+      .getByRole("textbox")
+  ).toHaveValue(saved, { timeout: LIVE_TIMEOUT });
 });
 
 test("Escape cancels without saving", async ({ page: studio }) => {

--- a/apps/web/tests/e2e/presentation-inline-edit.spec.ts
+++ b/apps/web/tests/e2e/presentation-inline-edit.spec.ts
@@ -34,17 +34,19 @@ const boldSpan = () =>
     { id: draftId }
   );
 
-// The overlay arms the editor only while hovered, so a double-click can land
-// before it is armed.
+// A double-click before the text cursor marks the element armed opens the
+// field through stock click-to-edit instead.
 const armInlineEdit = async (target: Locator) => {
-  await expect(async () => {
-    await target.hover();
-    await target.dblclick();
-    await expect(target).toHaveAttribute("contenteditable", "plaintext-only", {
-      timeout: 1000,
-    });
-  }).toPass({ timeout: 30_000 });
+  await target.hover();
+  await expect(target).toHaveCSS("cursor", "text", { timeout: 30_000 });
+  await target.dblclick();
+  await expect(target).toHaveAttribute("contenteditable", "plaintext-only");
 };
+
+const studioTitleField = (studio: Page) =>
+  studio
+    .getByTestId('field-pageBuilder[_key=="hero"].title')
+    .getByRole("textbox");
 
 // Without a field open in the Studio, so the double-click is what opens it.
 const openPreview = async (studio: Page) => {
@@ -102,16 +104,17 @@ test("double-click types into a heading and Enter saves it once", async ({
   await expect(heading).toHaveAttribute("contenteditable", "plaintext-only");
   // Keystrokes that reached the Studio form would have autosaved by now.
   expect(await heroTitle()).toBe(doc.heading);
+  // The field must not be open yet, or the assertion after Enter proves nothing.
+  await expect(studioTitleField(studio)).toHaveCount(0);
 
+  // Enter must open the field wherever the pointer is.
+  await studio.mouse.move(0, 0);
   await studio.keyboard.press("Enter");
   await expect.poll(soft(heroTitle), { timeout: SYNC_TIMEOUT }).toBe(saved);
   await expect(heading).not.toHaveAttribute("contenteditable");
-  // Enter is what opens the field in the Studio.
-  await expect(
-    studio
-      .getByTestId('field-pageBuilder[_key=="hero"].title')
-      .getByRole("textbox")
-  ).toHaveValue(saved, { timeout: LIVE_TIMEOUT });
+  await expect(studioTitleField(studio)).toHaveValue(saved, {
+    timeout: LIVE_TIMEOUT,
+  });
 });
 
 test("Escape cancels without saving", async ({ page: studio }) => {
@@ -119,14 +122,19 @@ test("Escape cancels without saving", async ({ page: studio }) => {
   const heading = preview.getByRole("heading", { level: 1, name: saved });
   await expect(heading).toBeVisible({ timeout: LIVE_TIMEOUT });
 
+  const revBefore = await client.fetch<string>("*[_id == $id][0]._rev", {
+    id: draftId,
+  });
   await armInlineEdit(heading);
   await studio.keyboard.type(" discarded");
   await studio.keyboard.press("Escape");
   await expect(heading).not.toHaveAttribute("contenteditable");
   await expect(heading).not.toContainText("discarded");
-  // Long enough for a stray save to land before asserting there was none.
+  // Long enough for a stray write to land before asserting there was none.
   await studio.waitForTimeout(2000);
-  expect(await heroTitle()).toBe(saved);
+  expect(
+    await client.fetch<string>("*[_id == $id][0]._rev", { id: draftId })
+  ).toBe(revBefore);
 });
 
 test("rich text: edits a bold run's words and keeps it bold", async ({

--- a/packages/sanity-blocks/src/cta/index.tsx
+++ b/packages/sanity-blocks/src/cta/index.tsx
@@ -58,7 +58,10 @@ export function CTABlock({
           <div className="flex max-w-[690px] flex-col items-start gap-6 lg:min-w-0">
             <BlockEyebrow eyebrow={eyebrow} />
             <div className="flex flex-col items-start gap-4">
-              <h2 className="font-normal text-3xl text-foreground leading-tight tracking-[-0.24px] md:text-4xl lg:text-5xl">
+              <h2
+                className="font-normal text-3xl text-foreground leading-tight tracking-[-0.24px] md:text-4xl lg:text-5xl"
+                data-inline-edit
+              >
                 {title}
               </h2>
               <RichText
@@ -73,7 +76,10 @@ export function CTABlock({
             // shrinks and wraps, so the card never overflows its dotted frame.
             <div className="bleed-x flex flex-col items-start gap-2 lg:mx-0 lg:w-[557px] lg:shrink-0">
               {usedByTeams?.title && (
-                <p className="px-4 font-light font-mono text-sm text-zinc-600 uppercase leading-6 tracking-[0.24px] lg:px-0 dark:text-zinc-300">
+                <p
+                  className="px-4 font-light font-mono text-sm text-zinc-600 uppercase leading-6 tracking-[0.24px] lg:px-0 dark:text-zinc-300"
+                  data-inline-edit
+                >
                   {usedByTeams.title}
                 </p>
               )}

--- a/packages/sanity-blocks/src/faq-accordion/index.tsx
+++ b/packages/sanity-blocks/src/faq-accordion/index.tsx
@@ -203,12 +203,18 @@ function FaqHeader({
       {(title || subtitle) && (
         <div className="flex flex-col gap-5">
           {title && (
-            <h2 className="font-normal text-4xl text-foreground leading-tight tracking-[-0.24px] md:text-5xl">
+            <h2
+              className="font-normal text-4xl text-foreground leading-tight tracking-[-0.24px] md:text-5xl"
+              data-inline-edit
+            >
               {title}
             </h2>
           )}
           {subtitle && (
-            <p className="body-text max-w-xl text-muted-foreground">
+            <p
+              className="body-text max-w-xl text-muted-foreground"
+              data-inline-edit
+            >
               {subtitle}
             </p>
           )}
@@ -224,7 +230,9 @@ function FaqContactLink({ link }: Readonly<{ link: FaqLink }>) {
   return (
     <div className="flex flex-wrap items-center justify-end gap-2">
       {link.title && (
-        <p className="text-base text-muted-foreground">{link.title}</p>
+        <p className="text-base text-muted-foreground" data-inline-edit>
+          {link.title}
+        </p>
       )}
       <Link
         aria-label={link.description ?? link.title ?? "Learn more"}

--- a/packages/sanity-blocks/src/feature-cards-icon/index.tsx
+++ b/packages/sanity-blocks/src/feature-cards-icon/index.tsx
@@ -37,7 +37,10 @@ function FeatureCardItem({ card }: Readonly<{ card: FeatureCard }>) {
       {/* Dissolved on lg so heading and body land in the shared subgrid rows. */}
       <div className="flex min-w-0 flex-col gap-2 lg:contents">
         {title ? (
-          <h3 className="text-balance break-words font-medium text-xl leading-8 lg:row-start-2 lg:mb-2 lg:min-w-0">
+          <h3
+            className="text-balance break-words font-medium text-xl leading-8 lg:row-start-2 lg:mb-2 lg:min-w-0"
+            data-inline-edit
+          >
             {title}
           </h3>
         ) : null}

--- a/packages/sanity-blocks/src/hero/hero.test.tsx
+++ b/packages/sanity-blocks/src/hero/hero.test.tsx
@@ -1,6 +1,29 @@
 import { HeroBlock } from "@workspace/sanity-blocks/hero/index";
 import { renderToStaticMarkup } from "react-dom/server";
 
+// The flag arms plain-string typing, honoured only where the element's one
+// child is that text. Portable Text is armed by span path, so the intro stays
+// unflagged: a whole paragraph is not one string.
+test("HeroBlock flags its heading and badge, and nothing else, for inline edits", () => {
+  const html = renderToStaticMarkup(
+    <HeroBlock
+      badge="New"
+      richText={[
+        {
+          _type: "block",
+          _key: "block-1",
+          children: [{ _type: "span", text: "Intro copy." }],
+        },
+      ]}
+      title="Type here"
+    />
+  );
+
+  expect(html).toMatch(/<h1[^>]*data-inline-edit[^>]*>Type here<\/h1>/);
+  expect(html).toMatch(/<span[^>]*data-inline-edit[^>]*>New<\/span>/);
+  expect(html.match(/data-inline-edit/g)).toHaveLength(2);
+});
+
 test("HeroBlock renders the title and button content", () => {
   const html = renderToStaticMarkup(
     <HeroBlock

--- a/packages/sanity-blocks/src/hero/index.tsx
+++ b/packages/sanity-blocks/src/hero/index.tsx
@@ -155,7 +155,10 @@ export function HeroBlock({
     <div className="container grid gap-8 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end lg:gap-12">
       <div className="grid gap-5">
         <BlockEyebrow eyebrow={badge} />
-        <h1 className="hero-enter max-w-[827px] text-pretty break-words font-normal text-4xl text-foreground leading-[1.1] tracking-[-0.24px] sm:text-5xl lg:text-[64px]">
+        <h1
+          className="hero-enter max-w-[827px] text-pretty break-words font-normal text-4xl text-foreground leading-[1.1] tracking-[-0.24px] sm:text-5xl lg:text-[64px]"
+          data-inline-edit
+        >
           {title}
         </h1>
         <RichText

--- a/packages/sanity-blocks/src/internal/block-eyebrow.tsx
+++ b/packages/sanity-blocks/src/internal/block-eyebrow.tsx
@@ -6,7 +6,10 @@ export function BlockEyebrow({
   }
 
   return (
-    <span className="inline-flex w-fit items-center self-start justify-self-start border border-border bg-background px-3 py-1.5 font-mono text-muted-foreground text-sm uppercase leading-[18px] tracking-[0.28px]">
+    <span
+      className="inline-flex w-fit items-center self-start justify-self-start border border-border bg-background px-3 py-1.5 font-mono text-muted-foreground text-sm uppercase leading-[18px] tracking-[0.28px]"
+      data-inline-edit
+    >
       {eyebrow}
     </span>
   );

--- a/packages/sanity-blocks/src/internal/block-header.tsx
+++ b/packages/sanity-blocks/src/internal/block-header.tsx
@@ -21,7 +21,11 @@ export function BlockHeader({
     <div className="flex flex-col items-start gap-6">
       <BlockEyebrow eyebrow={eyebrow} />
       <div className="flex flex-col items-start gap-5">
-        {title ? <h2 className="max-w-2xl block-title">{title}</h2> : null}
+        {title ? (
+          <h2 className="max-w-2xl block-title" data-inline-edit>
+            {title}
+          </h2>
+        ) : null}
         {children}
       </div>
     </div>

--- a/packages/sanity-blocks/src/rich-text-block/index.tsx
+++ b/packages/sanity-blocks/src/rich-text-block/index.tsx
@@ -18,7 +18,11 @@ export function RichTextBlock({
       <div className="container">
         <div className="flex flex-col items-start gap-6">
           <BlockEyebrow eyebrow={eyebrow} />
-          {title && <h2 className="max-w-2xl block-title">{title}</h2>}
+          {title && (
+            <h2 className="max-w-2xl block-title" data-inline-edit>
+              {title}
+            </h2>
+          )}
         </div>
         {richText && (
           <div className="mt-8 max-w-3xl">

--- a/packages/sanity-blocks/src/showcase-grid/index.tsx
+++ b/packages/sanity-blocks/src/showcase-grid/index.tsx
@@ -175,7 +175,10 @@ function ShowcaseHeader({
   return (
     <div className="mx-auto flex max-w-4xl flex-col items-center gap-4 text-center">
       {title ? (
-        <h2 className="block-title text-balance lg:text-[64px] lg:leading-[1.1]">
+        <h2
+          className="block-title text-balance lg:text-[64px] lg:leading-[1.1]"
+          data-inline-edit
+        >
           {title}
         </h2>
       ) : null}

--- a/packages/sanity-blocks/src/subscribe-newsletter/index.tsx
+++ b/packages/sanity-blocks/src/subscribe-newsletter/index.tsx
@@ -84,12 +84,14 @@ function TestimonialPanel({
             )}
             <div className="flex flex-col text-base leading-6">
               {authorName && (
-                <span className="font-medium text-foreground">
+                <span className="font-medium text-foreground" data-inline-edit>
                   {authorName}
                 </span>
               )}
               {authorRole && (
-                <span className="text-muted-foreground">{authorRole}</span>
+                <span className="text-muted-foreground" data-inline-edit>
+                  {authorRole}
+                </span>
               )}
             </div>
           </div>
@@ -131,7 +133,10 @@ export function SubscribeNewsletter({
           <div className="flex max-w-3xl flex-col items-start gap-8 pb-12">
             <div className="flex flex-col items-start gap-5">
               {title && (
-                <h2 className="max-w-none text-balance font-normal text-4xl text-foreground leading-tight tracking-[-0.24px] sm:text-5xl">
+                <h2
+                  className="max-w-none text-balance font-normal text-4xl text-foreground leading-tight tracking-[-0.24px] sm:text-5xl"
+                  data-inline-edit
+                >
                   {title}
                 </h2>
               )}

--- a/packages/sanity-blocks/src/video-feature/index.tsx
+++ b/packages/sanity-blocks/src/video-feature/index.tsx
@@ -42,7 +42,10 @@ export function VideoFeature({
           <figure className="grid gap-3">
             <MuxVideo options={video} title={title} video={video?.asset} />
             {caption && (
-              <figcaption className="text-muted-foreground text-sm">
+              <figcaption
+                className="text-muted-foreground text-sm"
+                data-inline-edit
+              >
                 {caption}
               </figcaption>
             )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@sanity/client':
         specifier: 'catalog:'
         version: 7.26.2
+      '@sanity/mutate':
+        specifier: ^0.18.1
+        version: 0.18.1(xstate@5.32.5)
       '@sanity/visual-editing':
         specifier: ^6.1.1
         version: 6.1.1(@sanity/client@7.26.2)(@types/react@19.2.18)(next@16.3.3(@babel/core@7.29.7(supports-color@8.1.1))(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)


### PR DESCRIPTION
## What this adds

- Editors can now change text right on the page in Presentation.
- Before, clicking text only opened its field in the Studio form.

## How to use it

1. Open a page in Presentation.
2. Double-click a heading, label, caption, or a line of rich text.
3. Type. Backspace, paste and undo work as normal.
4. Press **Enter**, or click somewhere else, to save.
5. Press **Escape** to cancel.
6. The Studio form shows the new text. Publish as usual.

Nothing is saved if the text didn't change or was cleared.

## How it works

1. **We mark what can be edited.** Blocks tag their headings, labels, captions and testimonial names. Rich text works without a tag.
2. **Double-click turns the text into a text box.** It only happens inside Presentation.
3. **We remove Sanity's hidden characters first.** Every piece of text on the preview carries invisible tracking characters. Without this step, Backspace would delete those first and look broken.
4. **Nothing saves while you type.** Saving reloads the page content, which would move the cursor. If the page updates anyway (say, someone edits the same field in the Studio), your typing is put back.
5. **One save at the end.** On Enter or click-away, the new text goes to the draft through Sanity's own save helper, `useDocuments`.
6. **The old text comes back** if you cancel, change nothing, or the save fails.

## What you can't edit on the page

- Buttons and links
- Images and videos
- Text fields that can hold more than one line
- In rich text, plain words in a paragraph that also has bold text or a link
- On phones and tablets, because there is no double-click
- While viewing a scheduled release, because saves always go to the draft

These still open in the Studio form when clicked.

## Not in this PR: formatting

- **What:** you can't add or remove bold, italic or links on the page. Use the Studio form for that. Formatting that is already there is kept when you edit the words.
- **Why:** Sanity stores bold or linked text as separate pieces, each with its own marks. Changing formatting means splitting and joining those pieces, which needs a real rich text editor, not just typing.
- **The option:** Sanity's own editor package, `@portabletext/editor`, can do it.
- **Trade-off:** it adds a new dependency, a toolbar, styling to match the page, and more testing, roughly 3 to 5 days of work. Editing only the words keeps this change small and safe, and nothing already formatted gets lost. Formatting can follow as its own change.

## For reviewers

- `apps/web/src/components/overlay-components.tsx` decides which text can be edited.
- `apps/web/src/components/inline-text.tsx` does the editing and the save.
- `apps/web/src/components/visual-editing-layer.tsx` passes these tools to `<VisualEditing>`.
- Blocks in `packages/sanity-blocks` get a `data-inline-edit` flag on their plain text.
- Adds `@sanity/mutate` to `apps/web`, the same version `@sanity/visual-editing` already uses.
- Saving is last-write-wins, the same as the Studio form.

## Verification

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm --filter @workspace/sanity-blocks test`
- [x] In Presentation, double-click a block title, type, press Enter: the draft and the Studio field update (manual)
- [x] Select a rich text paragraph with no formatting, paste over it, press Enter: the new text saves (manual)
- [x] Escape, or leaving the text unchanged, saves nothing (manual)
- [x] Outside Presentation, double-click does nothing (manual)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline editing for supported text fields in Visual Editing.
  - Double-click content to edit, then save when focus leaves the field.
  - Supports headings, labels, captions, titles, and rich-text content while preserving formatting.
  - Added safeguards for canceling edits, unchanged or empty values, and unsupported content.
  - Inline editing is available for draft content in Presentation only; published content remains unchanged.

- **Documentation**
  - Updated Visual Editing guidance for supported content, safeguards, and draft-only workflows.

- **Tests**
  - Added coverage for inline editing and supported Hero content markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->